### PR TITLE
feat: Implement Mobile Profile Management components

### DIFF
--- a/src/components/mobile/PullToRefresh.tsx
+++ b/src/components/mobile/PullToRefresh.tsx
@@ -1,0 +1,287 @@
+import * as React from 'react';
+import {
+  AccessibilityInfo,
+  ActivityIndicator,
+  Animated,
+  Easing,
+  Pressable,
+  StyleProp,
+  StyleSheet,
+  View,
+  ViewStyle,
+} from 'react-native';
+
+type AnyScrollComponent = React.ComponentType<any>;
+
+export interface PullToRefreshProps {
+  /**
+   * A scrollable component to render (e.g. Animated.ScrollView, FlatList, SectionList).
+   * Default: Animated.ScrollView
+   */
+  ScrollComponent?: AnyScrollComponent;
+  /** Props forwarded to the scroll component (data/renderItem/etc. for lists). */
+  scrollProps?: Record<string, unknown>;
+  /** Content to render inside ScrollView-like components. */
+  children?: React.ReactNode;
+
+  /** Called when refresh triggers. Can return a promise. */
+  onRefresh: () => void | Promise<void>;
+  /** External refreshing state (optional). If omitted, managed internally. */
+  refreshing?: boolean;
+
+  /** Pull distance (px) required to trigger refresh. */
+  threshold?: number;
+  /** Max pull distance for visual feedback (px). */
+  maxPull?: number;
+
+  /** Optional container style. */
+  style?: StyleProp<ViewStyle>;
+  /** Optional indicator container style. */
+  indicatorStyle?: StyleProp<ViewStyle>;
+
+  /** Accessibility label for the fallback refresh button. */
+  refreshA11yLabel?: string;
+  /** Show an explicit button fallback for screen readers. */
+  showA11yFallbackButton?: boolean;
+}
+
+function clamp(v: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, v));
+}
+
+/**
+ * Pull-to-refresh wrapper with smooth Animated feedback.
+ *
+ * Notes:
+ * - Uses responder capture only when at top and user is pulling down.
+ * - Avoids re-renders during drag by updating Animated.Value directly.
+ * - Provides a screen-reader friendly button fallback (optional).
+ */
+export function PullToRefresh(props: PullToRefreshProps) {
+  const {
+    ScrollComponent = Animated.ScrollView,
+    scrollProps,
+    children,
+    onRefresh,
+    refreshing: refreshingProp,
+    threshold = 80,
+    maxPull = 140,
+    style,
+    indicatorStyle,
+    refreshA11yLabel = 'Refresh content',
+    showA11yFallbackButton = true,
+  } = props;
+
+  const pullY = React.useRef(new Animated.Value(0)).current;
+  const lastPullRef = React.useRef(0);
+  const scrollYRef = React.useRef(0);
+  const startYRef = React.useRef<number | null>(null);
+  const pullingRef = React.useRef(false);
+  const inFlightRef = React.useRef(false);
+
+  const [internalRefreshing, setInternalRefreshing] = React.useState(false);
+  const refreshing = refreshingProp ?? internalRefreshing;
+
+  const [screenReaderEnabled, setScreenReaderEnabled] = React.useState(false);
+
+  React.useEffect(() => {
+    let mounted = true;
+    AccessibilityInfo.isScreenReaderEnabled().then((enabled) => {
+      if (mounted) setScreenReaderEnabled(enabled);
+    });
+    const sub = AccessibilityInfo.addEventListener?.('screenReaderChanged', (enabled) => {
+      setScreenReaderEnabled(Boolean(enabled));
+    });
+    return () => {
+      mounted = false;
+      // RN types vary by version; guard-remove.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (sub as any)?.remove?.();
+    };
+  }, []);
+
+  const animatePullTo = React.useCallback(
+    (toValue: number) => {
+      Animated.timing(pullY, {
+        toValue,
+        duration: 180,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }).start();
+    },
+    [pullY],
+  );
+
+  const runRefresh = React.useCallback(async () => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    if (refreshingProp == null) setInternalRefreshing(true);
+    try {
+      await onRefresh();
+    } finally {
+      if (refreshingProp == null) setInternalRefreshing(false);
+      inFlightRef.current = false;
+    }
+  }, [onRefresh, refreshingProp]);
+
+  // Keep indicator visible while refreshing.
+  React.useEffect(() => {
+    if (refreshing) animatePullTo(Math.min(threshold, maxPull));
+    else animatePullTo(0);
+  }, [animatePullTo, maxPull, refreshing, threshold]);
+
+  const onScroll = React.useCallback((e: any) => {
+    scrollYRef.current = e?.nativeEvent?.contentOffset?.y ?? 0;
+    // Forward if consumer provided their own onScroll.
+    const consumerOnScroll = (scrollProps as any)?.onScroll;
+    consumerOnScroll?.(e);
+  }, [scrollProps]);
+
+  const canStartPull = () => !refreshing && scrollYRef.current <= 0;
+
+  const responderHandlers = React.useMemo(
+    () => ({
+      onStartShouldSetResponder: () => false,
+      onMoveShouldSetResponder: (e: any) => {
+        if (!canStartPull()) return false;
+        const y0 = startYRef.current;
+        const pageY = e?.nativeEvent?.pageY;
+        if (typeof pageY !== 'number') return false;
+        if (y0 == null) return false;
+        const dy = pageY - y0;
+        // Only capture if user is pulling down intentionally.
+        return dy > 4;
+      },
+      onResponderGrant: (e: any) => {
+        startYRef.current = e?.nativeEvent?.pageY ?? null;
+        pullingRef.current = false;
+      },
+      onResponderMove: (e: any) => {
+        if (!canStartPull()) return;
+        const y0 = startYRef.current;
+        const pageY = e?.nativeEvent?.pageY;
+        if (typeof pageY !== 'number' || y0 == null) return;
+
+        const dy = Math.max(0, pageY - y0);
+        if (dy <= 0) return;
+
+        pullingRef.current = true;
+        // Resistance curve: feels more "native" than linear.
+        const resisted = maxPull * (1 - Math.exp(-dy / 120));
+        const next = clamp(resisted, 0, maxPull);
+        lastPullRef.current = next;
+        pullY.setValue(next);
+      },
+      onResponderRelease: async () => {
+        const pulled = lastPullRef.current;
+
+        startYRef.current = null;
+
+        if (pulled >= threshold && !refreshing) {
+          animatePullTo(Math.min(threshold, maxPull));
+          await runRefresh();
+          animatePullTo(0);
+        } else {
+          animatePullTo(0);
+        }
+        pullingRef.current = false;
+        lastPullRef.current = 0;
+      },
+      onResponderTerminate: () => {
+        startYRef.current = null;
+        pullingRef.current = false;
+        lastPullRef.current = 0;
+        animatePullTo(0);
+      },
+      onResponderTerminationRequest: () => true,
+    }),
+    [animatePullTo, maxPull, pullY, refreshing, runRefresh, threshold],
+  );
+
+  const progress = pullY.interpolate({
+    inputRange: [0, threshold],
+    outputRange: [0, 1],
+    extrapolate: 'clamp',
+  });
+
+  return (
+    <View style={[styles.container, style]} {...responderHandlers}>
+      {showA11yFallbackButton && screenReaderEnabled ? (
+        <View style={styles.a11yRow}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={refreshA11yLabel}
+            onPress={() => {
+              if (refreshing) return;
+              void runRefresh();
+            }}
+            style={styles.a11yButton}
+          >
+            <Animated.Text style={styles.a11yButtonText}>Refresh</Animated.Text>
+          </Pressable>
+        </View>
+      ) : null}
+
+      <Animated.View
+        pointerEvents="none"
+        style={[
+          styles.indicator,
+          indicatorStyle,
+          {
+            transform: [{ translateY: pullY }],
+            opacity: progress,
+          },
+        ]}
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+      >
+        <ActivityIndicator animating={refreshing} />
+      </Animated.View>
+
+      <Animated.View style={{ transform: [{ translateY: pullY }] }}>
+        <ScrollComponent
+          // Keep scroll smooth; only our outer responder captures when at top + pulling down.
+          scrollEventThrottle={16}
+          {...(scrollProps as any)}
+          onScroll={onScroll}
+        >
+          {children}
+        </ScrollComponent>
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    overflow: 'hidden',
+  },
+  indicator: {
+    position: 'absolute',
+    top: -44,
+    left: 0,
+    right: 0,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  a11yRow: {
+    paddingHorizontal: 12,
+    paddingTop: 8,
+    paddingBottom: 4,
+  },
+  a11yButton: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 10,
+    backgroundColor: '#e5e7eb',
+  },
+  a11yButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#111827',
+  },
+});
+

--- a/src/hooks/useGestures.ts
+++ b/src/hooks/useGestures.ts
@@ -1,0 +1,252 @@
+import * as React from 'react';
+import { AccessibilityInfo } from 'react-native';
+import type { GestureResponderEvent, ViewProps } from 'react-native';
+
+/**
+ * A tiny gesture "arbiter" to prevent recognizers (swipe/pinch/long-press/etc.)
+ * from interfering with each other.
+ *
+ * Design:
+ * - A gesture can "claim" exclusivity once it is confident it should win.
+ * - While a gesture is active, other gestures should ignore move/end events.
+ * - Optional priority lets you prefer e.g. pinch over swipe.
+ *
+ * This is intentionally framework-agnostic: individual gesture hooks use the
+ * coordinator but still implement their own recognition logic.
+ */
+
+export type GestureId = string;
+
+export interface GestureClaimOptions {
+  /**
+   * Higher priority claims can pre-empt lower ones before activation.
+   * Once a gesture is active, it stays active until it releases.
+   */
+  priority?: number;
+}
+
+export interface GestureCoordinator {
+  /** Attempt to claim exclusivity for a gesture. Returns true if granted. */
+  tryClaim: (id: GestureId, options?: GestureClaimOptions) => boolean;
+  /** Release exclusivity if currently owned by `id`. */
+  release: (id: GestureId) => void;
+  /** True if any gesture is currently active. */
+  hasActiveGesture: () => boolean;
+  /** True if `id` is the currently active gesture. */
+  isActive: (id: GestureId) => boolean;
+  /** The active gesture id, if any. */
+  getActiveId: () => GestureId | null;
+}
+
+export interface UseGesturesOptions {
+  /**
+   * If true, claims are disabled (gestures still detect but won't "lock").
+   * Useful as a "graceful degrade" switch if you want to avoid complex
+   * interactions in some contexts.
+   */
+  disabled?: boolean;
+}
+
+export function useGestures(options: UseGesturesOptions = {}): GestureCoordinator {
+  const { disabled = false } = options;
+
+  const activeIdRef = React.useRef<GestureId | null>(null);
+
+  const tryClaim = React.useCallback<GestureCoordinator['tryClaim']>(
+    (id, claimOptions) => {
+      if (disabled) return false;
+
+      const priority = claimOptions?.priority ?? 0;
+
+      // If no active gesture, allow.
+      if (activeIdRef.current == null) {
+        activeIdRef.current = id;
+        void priority; // retained for future pre-emption logic
+        return true;
+      }
+
+      // If already active, only the owner is allowed.
+      if (activeIdRef.current === id) return true;
+
+      // Pre-activation arbitration: allow a higher priority gesture to take the lock
+      // *only* if we haven't meaningfully committed yet.
+      // For simplicity we treat "activeIdRef.current is set" as committed, so no pre-emption.
+      // If you need pre-emption, add an explicit "candidate" state.
+      return false;
+    },
+    [disabled],
+  );
+
+  const release = React.useCallback<GestureCoordinator['release']>((id) => {
+    if (activeIdRef.current === id) {
+      activeIdRef.current = null;
+    }
+  }, []);
+
+  const hasActiveGesture = React.useCallback(() => activeIdRef.current != null, []);
+  const isActive = React.useCallback((id: GestureId) => activeIdRef.current === id, []);
+  const getActiveId = React.useCallback(() => activeIdRef.current, []);
+
+  // Expose stable object identity for easy passing across hooks.
+  return React.useMemo(
+    () => ({
+      tryClaim,
+      release,
+      hasActiveGesture,
+      isActive,
+      getActiveId,
+    }),
+    [tryClaim, release, hasActiveGesture, isActive, getActiveId],
+  );
+}
+
+export interface UseDoubleTapOptions {
+  /** Max delay between taps (ms). */
+  maxDelayMs?: number;
+  /** Cancel if finger moves beyond this distance (px). */
+  maxMoveDistance?: number;
+  /**
+   * Called on successful double tap.
+   * Note: screen readers often reserve double-tap for "activate"; by default
+   * we disable recognition when a screen reader is enabled.
+   */
+  onDoubleTap: (info: { pageX: number; pageY: number }) => void;
+  /** Optional single-tap callback if the second tap doesn't arrive in time. */
+  onSingleTap?: (info: { pageX: number; pageY: number }) => void;
+  /** Disable recognition when screen reader is enabled (default true). */
+  disableWhenScreenReaderEnabled?: boolean;
+}
+
+export type DoubleTapHandlers = Pick<
+  ViewProps,
+  | 'onStartShouldSetResponder'
+  | 'onMoveShouldSetResponder'
+  | 'onResponderGrant'
+  | 'onResponderMove'
+  | 'onResponderRelease'
+  | 'onResponderTerminate'
+  | 'onResponderTerminationRequest'
+>;
+
+function distanceSq(ax: number, ay: number, bx: number, by: number): number {
+  const dx = ax - bx;
+  const dy = ay - by;
+  return dx * dx + dy * dy;
+}
+
+/**
+ * Double-tap recognizer (no dependencies).
+ * - Uses responder events so it works on native.
+ * - Avoids interfering with accessibility: disabled by default when a screen reader is enabled.
+ */
+export function useDoubleTap(options: UseDoubleTapOptions) {
+  const {
+    maxDelayMs = 250,
+    maxMoveDistance = 12,
+    onDoubleTap,
+    onSingleTap,
+    disableWhenScreenReaderEnabled = true,
+  } = options;
+
+  const [screenReaderEnabled, setScreenReaderEnabled] = React.useState(false);
+
+  React.useEffect(() => {
+    let mounted = true;
+    AccessibilityInfo.isScreenReaderEnabled().then((enabled) => {
+      if (mounted) setScreenReaderEnabled(enabled);
+    });
+    const sub = AccessibilityInfo.addEventListener?.('screenReaderChanged', (enabled) => {
+      setScreenReaderEnabled(Boolean(enabled));
+    });
+    return () => {
+      mounted = false;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (sub as any)?.remove?.();
+    };
+  }, []);
+
+  const tap1Ref = React.useRef<{ t: number; x: number; y: number } | null>(null);
+  const startRef = React.useRef<{ x: number; y: number } | null>(null);
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const movedTooFarRef = React.useRef(false);
+
+  const clearTimer = React.useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const reset = React.useCallback(() => {
+    clearTimer();
+    startRef.current = null;
+    tap1Ref.current = null;
+    movedTooFarRef.current = false;
+  }, [clearTimer]);
+
+  const handlers = React.useMemo<DoubleTapHandlers>(() => {
+    const disabled = disableWhenScreenReaderEnabled && screenReaderEnabled;
+
+    return {
+      onStartShouldSetResponder: (e) => !disabled && e.nativeEvent.touches.length === 1,
+      onMoveShouldSetResponder: (e) => !disabled && e.nativeEvent.touches.length === 1,
+      onResponderTerminationRequest: () => true,
+      onResponderGrant: (e) => {
+        if (disabled) return;
+        const { pageX: x, pageY: y } = e.nativeEvent;
+        startRef.current = { x, y };
+        movedTooFarRef.current = false;
+      },
+      onResponderMove: (e: GestureResponderEvent) => {
+        if (disabled) return;
+        const s = startRef.current;
+        if (!s) return;
+        const { pageX, pageY } = e.nativeEvent;
+        const maxSq = maxMoveDistance * maxMoveDistance;
+        if (distanceSq(pageX, pageY, s.x, s.y) > maxSq) movedTooFarRef.current = true;
+      },
+      onResponderRelease: (e) => {
+        if (disabled) return;
+        const { pageX: x, pageY: y } = e.nativeEvent;
+        const now = Date.now();
+
+        if (movedTooFarRef.current) {
+          reset();
+          return;
+        }
+
+        const tap1 = tap1Ref.current;
+        if (tap1 && now - tap1.t <= maxDelayMs) {
+          clearTimer();
+          tap1Ref.current = null;
+          onDoubleTap({ pageX: x, pageY: y });
+          return;
+        }
+
+        // First tap: wait for the second.
+        tap1Ref.current = { t: now, x, y };
+        clearTimer();
+        timerRef.current = setTimeout(() => {
+          const stored = tap1Ref.current;
+          tap1Ref.current = null;
+          if (stored) onSingleTap?.({ pageX: stored.x, pageY: stored.y });
+        }, maxDelayMs);
+      },
+      onResponderTerminate: () => reset(),
+    };
+  }, [
+    clearTimer,
+    disableWhenScreenReaderEnabled,
+    maxDelayMs,
+    maxMoveDistance,
+    onDoubleTap,
+    onSingleTap,
+    reset,
+    screenReaderEnabled,
+  ]);
+
+  React.useEffect(() => reset, [reset]);
+
+  return { doubleTapHandlers: handlers, resetDoubleTap: reset };
+}
+

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -1,0 +1,181 @@
+import * as React from 'react';
+import { Animated, Easing } from 'react-native';
+import type { GestureResponderEvent, ViewProps } from 'react-native';
+import type { GestureCoordinator } from './useGestures';
+
+export interface LongPressInfo {
+  pageX: number;
+  pageY: number;
+}
+
+export interface UseLongPressOptions {
+  /** How long the user must press before triggering (ms). */
+  durationMs?: number;
+  /** Cancel long press if finger moves more than this distance (px). */
+  maxMoveDistance?: number;
+  /** Called when long press triggers (includes touch point for positioning). */
+  onLongPress: (info: LongPressInfo) => void;
+  /** Optional callback when long press is cancelled. */
+  onCancel?: () => void;
+  /**
+   * Optional coordinator to prevent conflicts (e.g. swipe should cancel long-press).
+   * We only claim when about to trigger to avoid blocking scroll/swipe prematurely.
+   */
+  coordinator?: GestureCoordinator;
+  /** Identifier used by the coordinator (defaults to 'longPress'). */
+  id?: string;
+}
+
+export interface LongPressHandlers
+  extends Pick<
+    ViewProps,
+    | 'onStartShouldSetResponder'
+    | 'onMoveShouldSetResponder'
+    | 'onResponderGrant'
+    | 'onResponderMove'
+    | 'onResponderRelease'
+    | 'onResponderTerminate'
+    | 'onResponderTerminationRequest'
+  > {}
+
+function distanceSq(ax: number, ay: number, bx: number, by: number): number {
+  const dx = ax - bx;
+  const dy = ay - by;
+  return dx * dx + dy * dy;
+}
+
+/**
+ * Long-press recognizer with:
+ * - configurable duration
+ * - cancel-on-move
+ * - optional press highlight animation (via `pressProgress` Animated.Value)
+ */
+export function useLongPress(options: UseLongPressOptions) {
+  const {
+    durationMs = 500,
+    maxMoveDistance = 10,
+    onLongPress,
+    onCancel,
+    coordinator,
+    id = 'longPress',
+  } = options;
+
+  const pressProgress = React.useRef(new Animated.Value(0)).current;
+
+  const startRef = React.useRef<{ x: number; y: number } | null>(null);
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const firedRef = React.useRef(false);
+  const cancelledRef = React.useRef(false);
+
+  const clearTimer = React.useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const reset = React.useCallback(() => {
+    clearTimer();
+    startRef.current = null;
+    firedRef.current = false;
+    cancelledRef.current = false;
+    coordinator?.release(id);
+
+    Animated.timing(pressProgress, {
+      toValue: 0,
+      duration: 120,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: false, // progress is often used for opacity/bg, keep on JS
+    }).start();
+  }, [clearTimer, coordinator, id, pressProgress]);
+
+  const cancel = React.useCallback(() => {
+    if (cancelledRef.current) return;
+    cancelledRef.current = true;
+    onCancel?.();
+    reset();
+  }, [onCancel, reset]);
+
+  const handlers = React.useMemo<LongPressHandlers>(() => {
+    return {
+      onStartShouldSetResponder: (e) => e.nativeEvent.touches.length === 1,
+      onMoveShouldSetResponder: (e) => e.nativeEvent.touches.length === 1,
+      onResponderTerminationRequest: () => true,
+      onResponderGrant: (e) => {
+        if (e.nativeEvent.touches.length !== 1) return;
+        const { pageX: x, pageY: y } = e.nativeEvent;
+
+        startRef.current = { x, y };
+        firedRef.current = false;
+        cancelledRef.current = false;
+
+        Animated.timing(pressProgress, {
+          toValue: 1,
+          duration: durationMs,
+          easing: Easing.linear,
+          useNativeDriver: false,
+        }).start();
+
+        clearTimer();
+        timerRef.current = setTimeout(() => {
+          if (cancelledRef.current || firedRef.current) return;
+          // Claim only at trigger time so we don't block scroll/swipe prematurely.
+          const claimed = coordinator ? coordinator.tryClaim(id, { priority: 5 }) : true;
+          if (!claimed) {
+            cancel();
+            return;
+          }
+          firedRef.current = true;
+          const s = startRef.current;
+          if (s) onLongPress({ pageX: s.x, pageY: s.y });
+        }, durationMs);
+      },
+      onResponderMove: (e: GestureResponderEvent) => {
+        if (e.nativeEvent.touches.length !== 1) {
+          cancel();
+          return;
+        }
+        if (firedRef.current) return;
+        // If some other gesture claimed, long press should cancel.
+        if (coordinator?.hasActiveGesture() && !coordinator.isActive(id)) {
+          cancel();
+          return;
+        }
+
+        const s = startRef.current;
+        if (!s) return;
+        const { pageX, pageY } = e.nativeEvent;
+        const maxSq = maxMoveDistance * maxMoveDistance;
+        if (distanceSq(pageX, pageY, s.x, s.y) > maxSq) {
+          cancel();
+        }
+      },
+      onResponderRelease: () => {
+        // If it fired, keep progress at 1 briefly then reset.
+        if (!firedRef.current) onCancel?.();
+        reset();
+      },
+      onResponderTerminate: () => {
+        onCancel?.();
+        reset();
+      },
+    };
+  }, [
+    cancel,
+    clearTimer,
+    coordinator,
+    durationMs,
+    id,
+    maxMoveDistance,
+    onCancel,
+    onLongPress,
+    pressProgress,
+    reset,
+  ]);
+
+  // Defensive cleanup on unmount.
+  React.useEffect(() => reset, [reset]);
+
+  return { longPressHandlers: handlers, pressProgress, resetLongPress: reset };
+}
+

--- a/src/hooks/usePinchZoom.ts
+++ b/src/hooks/usePinchZoom.ts
@@ -1,0 +1,185 @@
+import * as React from 'react';
+import { Animated, Easing } from 'react-native';
+import type { GestureResponderEvent, ViewProps } from 'react-native';
+import type { GestureCoordinator } from './useGestures';
+
+export interface UsePinchZoomOptions {
+  /** Minimum allowed zoom scale. */
+  minScale?: number;
+  /** Maximum allowed zoom scale. */
+  maxScale?: number;
+  /** Starting scale (default 1). */
+  initialScale?: number;
+  /**
+   * If true, snaps back to 1 when gesture ends (common "image preview" UX).
+   * If false, clamps to min/max and keeps last scale.
+   */
+  resetOnEnd?: boolean;
+  /** Optional callback with final scale after end animation/clamp. */
+  onPinchEnd?: (scale: number) => void;
+  /**
+   * Optional coordinator to prevent conflicts (pinch should beat swipe).
+   */
+  coordinator?: GestureCoordinator;
+  /** Identifier used by the coordinator (defaults to 'pinch'). */
+  id?: string;
+}
+
+export interface PinchHandlers
+  extends Pick<
+    ViewProps,
+    | 'onStartShouldSetResponder'
+    | 'onMoveShouldSetResponder'
+    | 'onResponderGrant'
+    | 'onResponderMove'
+    | 'onResponderRelease'
+    | 'onResponderTerminate'
+    | 'onResponderTerminationRequest'
+  > {}
+
+function clamp(v: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, v));
+}
+
+function distance(a: { pageX: number; pageY: number }, b: { pageX: number; pageY: number }): number {
+  const dx = a.pageX - b.pageX;
+  const dy = a.pageY - b.pageY;
+  return Math.hypot(dx, dy);
+}
+
+/**
+ * Pinch-to-zoom implemented using responder events + Animated.Value.
+ * Performance notes:
+ * - We update the Animated.Value directly (no React state) during move.
+ * - We throttle updates with requestAnimationFrame to avoid flooding the bridge.
+ */
+export function usePinchZoom(options: UsePinchZoomOptions = {}) {
+  const {
+    minScale = 1,
+    maxScale = 3,
+    initialScale = 1,
+    resetOnEnd = false,
+    onPinchEnd,
+    coordinator,
+    id = 'pinch',
+  } = options;
+
+  const scale = React.useRef(new Animated.Value(initialScale)).current;
+
+  const baseScaleRef = React.useRef(initialScale);
+  const startDistanceRef = React.useRef<number | null>(null);
+  const activeRef = React.useRef(false);
+
+  const rafRef = React.useRef<number | null>(null);
+  const pendingScaleRef = React.useRef<number | null>(null);
+
+  const setScaleImmediate = React.useCallback(
+    (next: number) => {
+      baseScaleRef.current = clamp(next, minScale, maxScale);
+      scale.setValue(baseScaleRef.current);
+    },
+    [maxScale, minScale, scale],
+  );
+
+  const animateTo = React.useCallback(
+    (next: number) => {
+      const clamped = clamp(next, minScale, maxScale);
+      baseScaleRef.current = clamped;
+      Animated.timing(scale, {
+        toValue: clamped,
+        duration: 160,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }).start(({ finished }) => {
+        if (finished) onPinchEnd?.(clamped);
+      });
+    },
+    [maxScale, minScale, onPinchEnd, scale],
+  );
+
+  const resetPinch = React.useCallback(() => {
+    activeRef.current = false;
+    startDistanceRef.current = null;
+    pendingScaleRef.current = null;
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    coordinator?.release(id);
+  }, [coordinator, id]);
+
+  const scheduleScaleUpdate = React.useCallback(() => {
+    if (rafRef.current != null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      const pending = pendingScaleRef.current;
+      if (pending == null) return;
+      scale.setValue(pending);
+    });
+  }, [scale]);
+
+  const handlers = React.useMemo<PinchHandlers>(() => {
+    return {
+      onStartShouldSetResponder: (e) => e.nativeEvent.touches.length === 2,
+      onMoveShouldSetResponder: (e) => {
+        if (e.nativeEvent.touches.length !== 2) return false;
+        if (coordinator?.hasActiveGesture() && !coordinator.isActive(id)) return false;
+        return true;
+      },
+      onResponderTerminationRequest: () => true,
+      onResponderGrant: (e) => {
+        if (e.nativeEvent.touches.length !== 2) return;
+
+        // Pinch should generally win conflicts over swipe.
+        const claimed = coordinator ? coordinator.tryClaim(id, { priority: 10 }) : true;
+        if (!claimed) return;
+
+        activeRef.current = true;
+        const [t0, t1] = e.nativeEvent.touches;
+        startDistanceRef.current = distance(t0, t1);
+      },
+      onResponderMove: (e: GestureResponderEvent) => {
+        if (!activeRef.current) return;
+        if (e.nativeEvent.touches.length !== 2) return;
+        if (coordinator?.hasActiveGesture() && !coordinator.isActive(id)) return;
+
+        const startDistance = startDistanceRef.current;
+        if (!startDistance || startDistance <= 0) return;
+
+        const [t0, t1] = e.nativeEvent.touches;
+        const d = distance(t0, t1);
+        const raw = baseScaleRef.current * (d / startDistance);
+        const next = clamp(raw, minScale, maxScale);
+
+        pendingScaleRef.current = next;
+        scheduleScaleUpdate();
+      },
+      onResponderRelease: () => {
+        if (!activeRef.current) {
+          resetPinch();
+          return;
+        }
+
+        const current = pendingScaleRef.current ?? baseScaleRef.current;
+        if (resetOnEnd) {
+          animateTo(1);
+        } else {
+          animateTo(current);
+        }
+        resetPinch();
+      },
+      onResponderTerminate: () => {
+        resetPinch();
+      },
+    };
+  }, [animateTo, coordinator, id, maxScale, minScale, resetOnEnd, resetPinch, scheduleScaleUpdate]);
+
+  return {
+    pinchHandlers: handlers,
+    scale,
+    setScaleImmediate,
+    animateTo,
+    resetPinch,
+  };
+}
+

--- a/src/hooks/useSwipe.ts
+++ b/src/hooks/useSwipe.ts
@@ -1,0 +1,193 @@
+import * as React from 'react';
+import type { GestureResponderEvent, ViewProps } from 'react-native';
+import type { GestureCoordinator } from './useGestures';
+
+export type SwipeDirection = 'left' | 'right' | 'up' | 'down';
+
+export interface SwipeInfo {
+  direction: SwipeDirection;
+  /** Total distance in the dominant axis (px). */
+  distance: number;
+  /** Signed distance in X (px). */
+  dx: number;
+  /** Signed distance in Y (px). */
+  dy: number;
+  /** Approx. velocity in dominant axis (px/ms). */
+  velocity: number;
+  /** Time since gesture start (ms). */
+  durationMs: number;
+}
+
+export interface UseSwipeOptions {
+  /** Minimum movement (px) before a swipe is recognized. */
+  minDistance?: number;
+  /** If both axes move, require a ratio to decide the dominant axis. */
+  axisLockRatio?: number;
+  /** Called once when a swipe is recognized (after claiming). */
+  onSwipeStart?: (info: SwipeInfo) => void;
+  /** Called on release if swipe was recognized. */
+  onSwipeEnd?: (info: SwipeInfo) => void;
+  /** Called on release if swipe never met the threshold. */
+  onSwipeCancel?: () => void;
+  /**
+   * Optional coordinator to prevent conflicts (e.g. pinch vs swipe).
+   * If provided, swipe will only proceed if it can claim.
+   */
+  coordinator?: GestureCoordinator;
+  /** Identifier used by the coordinator (defaults to 'swipe'). */
+  id?: string;
+}
+
+export interface SwipeHandlers
+  extends Pick<
+    ViewProps,
+    | 'onStartShouldSetResponder'
+    | 'onMoveShouldSetResponder'
+    | 'onResponderGrant'
+    | 'onResponderMove'
+    | 'onResponderRelease'
+    | 'onResponderTerminate'
+    | 'onResponderTerminationRequest'
+  > {}
+
+function pickDirection(dx: number, dy: number): SwipeDirection {
+  if (Math.abs(dx) >= Math.abs(dy)) return dx >= 0 ? 'right' : 'left';
+  return dy >= 0 ? 'down' : 'up';
+}
+
+function nowMs(): number {
+  // Date.now is stable and cheap enough for gesture timestamps.
+  return Date.now();
+}
+
+/**
+ * Swipe detection using React Native's responder system (no external deps).
+ * - Avoids re-renders by keeping gesture state in refs.
+ * - Tries to avoid accidental swipes by requiring minDistance + axis lock ratio.
+ */
+export function useSwipe(options: UseSwipeOptions = {}) {
+  const {
+    minDistance = 18,
+    axisLockRatio = 1.15,
+    onSwipeStart,
+    onSwipeEnd,
+    onSwipeCancel,
+    coordinator,
+    id = 'swipe',
+  } = options;
+
+  const startRef = React.useRef<{
+    x: number;
+    y: number;
+    t: number;
+  } | null>(null);
+
+  const recognizedRef = React.useRef(false);
+  const lastRef = React.useRef<{ dx: number; dy: number; t: number }>({ dx: 0, dy: 0, t: 0 });
+
+  const reset = React.useCallback(() => {
+    startRef.current = null;
+    recognizedRef.current = false;
+    lastRef.current = { dx: 0, dy: 0, t: 0 };
+    coordinator?.release(id);
+  }, [coordinator, id]);
+
+  const buildInfo = React.useCallback(
+    (dx: number, dy: number, tNow: number): SwipeInfo => {
+      const start = startRef.current;
+      const t0 = start?.t ?? tNow;
+      const durationMs = Math.max(1, tNow - t0);
+      const direction = pickDirection(dx, dy);
+      const dominant = direction === 'left' || direction === 'right' ? dx : dy;
+      const distance = Math.abs(dominant);
+      const velocity = dominant / durationMs; // px/ms
+      return { direction, distance, dx, dy, velocity, durationMs };
+    },
+    [],
+  );
+
+  const handlers = React.useMemo<SwipeHandlers>(() => {
+    return {
+      onStartShouldSetResponder: (e) => {
+        // Single touch only.
+        return e.nativeEvent.touches.length === 1;
+      },
+      onMoveShouldSetResponder: (e) => {
+        // Don't become responder if another gesture is already active.
+        if (coordinator?.hasActiveGesture() && !coordinator.isActive(id)) return false;
+        return e.nativeEvent.touches.length === 1;
+      },
+      onResponderTerminationRequest: () => true,
+      onResponderGrant: (e) => {
+        const t = nowMs();
+        const { pageX: x, pageY: y } = e.nativeEvent;
+        startRef.current = { x, y, t };
+        recognizedRef.current = false;
+        lastRef.current = { dx: 0, dy: 0, t };
+      },
+      onResponderMove: (e: GestureResponderEvent) => {
+        if (e.nativeEvent.touches.length !== 1) return;
+
+        // If another gesture claimed, ignore.
+        if (coordinator?.hasActiveGesture() && !coordinator.isActive(id)) return;
+
+        const start = startRef.current;
+        if (!start) return;
+
+        const tNow = nowMs();
+        const dx = e.nativeEvent.pageX - start.x;
+        const dy = e.nativeEvent.pageY - start.y;
+
+        // Axis-lock heuristic to reduce accidental diagonal triggers.
+        const ax = Math.abs(dx);
+        const ay = Math.abs(dy);
+        const dominantIsX = ax >= ay * axisLockRatio;
+        const dominantIsY = ay >= ax * axisLockRatio;
+
+        if (!recognizedRef.current) {
+          const movedEnough = Math.max(ax, ay) >= minDistance;
+          if (!movedEnough) return;
+          if (!dominantIsX && !dominantIsY) return;
+
+          // Claim exclusivity only when we're confident it's a swipe.
+          const claimed = coordinator ? coordinator.tryClaim(id, { priority: 0 }) : true;
+          if (!claimed) return;
+
+          recognizedRef.current = true;
+          onSwipeStart?.(buildInfo(dx, dy, tNow));
+        }
+
+        lastRef.current = { dx, dy, t: tNow };
+      },
+      onResponderRelease: () => {
+        const start = startRef.current;
+        const { dx, dy, t } = lastRef.current;
+        const tNow = nowMs();
+
+        if (recognizedRef.current && start) {
+          onSwipeEnd?.(buildInfo(dx, dy, t || tNow));
+        } else {
+          onSwipeCancel?.();
+        }
+        reset();
+      },
+      onResponderTerminate: () => {
+        onSwipeCancel?.();
+        reset();
+      },
+    };
+  }, [
+    axisLockRatio,
+    buildInfo,
+    coordinator,
+    id,
+    minDistance,
+    onSwipeCancel,
+    onSwipeEnd,
+    onSwipeStart,
+    reset,
+  ]);
+
+  return { swipeHandlers: handlers, resetSwipe: reset };
+}
+


### PR DESCRIPTION
Closes #3  feat: add reusable mobile gesture system
Description
Summary
Add core gesture coordinator and double-tap support in src/hooks/useGestures.ts.
Implement reusable gesture hooks: src/hooks/useSwipe.ts, src/hooks/usePinchZoom.ts, src/hooks/useLongPress.ts.
Add pull-to-refresh UI + logic in src/components/mobile/PullToRefresh.tsx with animated indicator and refresh threshold.
Test Plan
Verify swipe, pinch, long-press, and double-tap callbacks fire as expected.
In PullToRefresh, pull from top of a list and confirm refresh only triggers past the threshold, and normal scrolling still works.