### PR TITLE
feat: implement offline request queue with retry and pending badge

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,20 +1,22 @@
-import React, { useEffect } from 'react';
 import { StatusBar } from 'expo-status-bar';
+import React, { useEffect } from 'react';
 import { LogBox } from 'react-native';
-import AppNavigator from './src/navigation/AppNavigator';
-import { useAppStore } from './src/store';
-import socketService from './src/services/socket';
-import { ErrorBoundary } from './src/components/common/ErrorBoundary';
 import "./global.css";
+import { ErrorBoundary } from './src/components/common/ErrorBoundary';
+import AppNavigator from './src/navigation/AppNavigator';
+import socketService from './src/services/socket';
+import { useAppStore } from './src/store';
 
 // Notification imports
 import { setupNotificationNavigation } from './src/navigation/linking';
-import { handleNotificationReceived } from './src/utils/notificationHandlers';
+import apiClient from './src/services/api/axios.config';
+import requestQueue from './src/services/api/requestQueue';
 import {
-  addNotificationReceivedListener,
-  getLastNotificationResponse,
-  removeNotificationListener,
+    addNotificationReceivedListener,
+    getLastNotificationResponse,
+    removeNotificationListener,
 } from './src/services/pushNotifications';
+import { handleNotificationReceived } from './src/utils/notificationHandlers';
 
 // Enable error logging to console (visible in Metro bundler)
 if (__DEV__) {
@@ -37,6 +39,9 @@ export default function App() {
   useEffect(() => {
     // Connect to socket when app starts
     socketService.connect();
+
+    // Start request queue monitoring
+    requestQueue.startMonitoring(apiClient);
 
     // Set up notification navigation handler
     const notificationCleanup = setupNotificationNavigation();

--- a/src/components/mobile/MobileHeader.tsx
+++ b/src/components/mobile/MobileHeader.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
-import { useSafeArea } from '../../hooks/useSafeArea';
-import { Menu, ArrowLeft, Bell } from 'lucide-react-native';
-import { useNavigation } from '@react-navigation/native';
 import { DrawerNavigationProp } from '@react-navigation/drawer';
+import { useNavigation } from '@react-navigation/native';
+import { ArrowLeft, Bell, Menu } from 'lucide-react-native';
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { usePendingRequests } from '../../hooks/usePendingRequests';
+import { useSafeArea } from '../../hooks/useSafeArea';
 
 interface MobileHeaderProps {
     title: string;
@@ -14,6 +15,7 @@ interface MobileHeaderProps {
 export const MobileHeader = ({ title, showBack = false, rightAction }: MobileHeaderProps) => {
     const { top } = useSafeArea();
     const navigation = useNavigation<DrawerNavigationProp<any>>();
+    const pendingCount = usePendingRequests();
 
     return (
         <View
@@ -46,13 +48,22 @@ export const MobileHeader = ({ title, showBack = false, rightAction }: MobileHea
 
             <View className="flex-row items-center">
                 {rightAction || (
-                    <TouchableOpacity 
-                        className="p-2"
-                        accessibilityRole="button"
-                        accessibilityLabel="View notifications"
-                    >
-                        <Bell color="#4B5563" size={20} />
-                    </TouchableOpacity>
+                    <View className="relative">
+                        <TouchableOpacity 
+                            className="p-2"
+                            accessibilityRole="button"
+                            accessibilityLabel="View notifications"
+                        >
+                            <Bell color="#4B5563" size={20} />
+                        </TouchableOpacity>
+                        {pendingCount > 0 && (
+                            <View className="absolute -top-1 -right-1 bg-red-500 rounded-full min-w-[18px] h-[18px] items-center justify-center">
+                                <Text className="text-white text-xs font-bold">
+                                    {pendingCount > 99 ? '99+' : pendingCount}
+                                </Text>
+                            </View>
+                        )}
+                    </View>
                 )}
             </View>
         </View>

--- a/src/hooks/usePendingRequests.ts
+++ b/src/hooks/usePendingRequests.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import requestQueue from '../services/api/requestQueue';
+
+/**
+ * Hook to get the number of pending offline requests
+ */
+export function usePendingRequests() {
+  const [pendingCount, setPendingCount] = useState(0);
+
+  useEffect(() => {
+    // Get initial count
+    requestQueue.getPendingCount().then(setPendingCount);
+
+    // Listen for changes
+    const unsubscribe = requestQueue.onPendingCountChange(setPendingCount);
+
+    return unsubscribe;
+  }, []);
+
+  return pendingCount;
+}

--- a/src/services/api/axios.config.ts
+++ b/src/services/api/axios.config.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosError, InternalAxiosRequestConfig } from "axios";
 import { getAccessToken, getRefreshToken, saveTokens } from "../secureStorage";
+import requestQueue from "./requestQueue";
 
 // ─── Client ───────────────────────────────────────────────────────────────────
 
@@ -56,6 +57,14 @@ apiClient.interceptors.response.use(
       } else if (error.response?.status !== 401) {
         console.error("API Error:", error.response?.data || error.message);
       }
+    }
+
+    // ── Queue network errors for retry ───────────────────────────────────
+    if (error.code === "ERR_NETWORK" || error.message === "Network Error") {
+      if (originalRequest) {
+        await requestQueue.addToQueue(originalRequest);
+      }
+      return Promise.reject(error);
     }
 
     // ── Token refresh on 401 ─────────────────────────────────────────────

--- a/src/services/api/requestQueue.ts
+++ b/src/services/api/requestQueue.ts
@@ -1,0 +1,169 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { InternalAxiosRequestConfig } from 'axios';
+import * as Network from 'expo-network';
+import logger from '../../utils/logger';
+
+// Queued request interface
+export interface QueuedRequest {
+  id: string;
+  config: InternalAxiosRequestConfig;
+  timestamp: number;
+  retries: number;
+  maxRetries: number;
+}
+
+const QUEUE_KEY = '@teachlink_request_queue';
+
+class RequestQueue {
+  private readonly MAX_RETRIES = 3;
+  private isProcessing = false;
+  private listeners: ((count: number) => void)[] = [];
+
+  /**
+   * Add a failed request to the queue
+   */
+  async addToQueue(config: InternalAxiosRequestConfig): Promise<void> {
+    try {
+      const queue = await this.getQueue();
+      const queuedRequest: QueuedRequest = {
+        id: this.generateId(),
+        config,
+        timestamp: Date.now(),
+        retries: 0,
+        maxRetries: this.MAX_RETRIES,
+      };
+      queue.push(queuedRequest);
+      await AsyncStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+      logger.info(`Added request to queue: ${config.method?.toUpperCase()} ${config.url}`);
+      this.notifyListeners(queue.length);
+    } catch (error) {
+      logger.error('Error adding request to queue:', error);
+    }
+  }
+
+  /**
+   * Get the current queue
+   */
+  async getQueue(): Promise<QueuedRequest[]> {
+    try {
+      const data = await AsyncStorage.getItem(QUEUE_KEY);
+      return data ? JSON.parse(data) : [];
+    } catch (error) {
+      logger.error('Error getting request queue:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Remove a request from the queue
+   */
+  async removeFromQueue(id: string): Promise<void> {
+    try {
+      const queue = await this.getQueue();
+      const filtered = queue.filter(req => req.id !== id);
+      await AsyncStorage.setItem(QUEUE_KEY, JSON.stringify(filtered));
+      this.notifyListeners(filtered.length);
+    } catch (error) {
+      logger.error('Error removing from queue:', error);
+    }
+  }
+
+  /**
+   * Increment retry count
+   */
+  async incrementRetry(id: string): Promise<void> {
+    try {
+      const queue = await this.getQueue();
+      const request = queue.find(req => req.id === id);
+      if (request) {
+        request.retries += 1;
+        await AsyncStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+      }
+    } catch (error) {
+      logger.error('Error incrementing retry:', error);
+    }
+  }
+
+  /**
+   * Process the queue when online
+   */
+  async processQueue(apiClient: any): Promise<void> {
+    if (this.isProcessing) return;
+
+    const isConnected = await this.checkConnectivity();
+    if (!isConnected) return;
+
+    this.isProcessing = true;
+    try {
+      const queue = await this.getQueue();
+      for (const request of queue) {
+        if (request.retries >= request.maxRetries) {
+          // Remove failed requests
+          await this.removeFromQueue(request.id);
+          continue;
+        }
+
+        try {
+          await apiClient(request.config);
+          await this.removeFromQueue(request.id);
+        } catch (error) {
+          await this.incrementRetry(request.id);
+        }
+      }
+    } catch (error) {
+      logger.error('Error processing queue:', error);
+    } finally {
+      this.isProcessing = false;
+    }
+  }
+
+  /**
+   * Start monitoring network and processing queue
+   */
+  startMonitoring(apiClient: any): void {
+    const interval = setInterval(async () => {
+      await this.processQueue(apiClient);
+    }, 10000); // Check every 10 seconds
+
+    // Also process immediately if online
+    this.processQueue(apiClient);
+  }
+
+  /**
+   * Get pending requests count
+   */
+  async getPendingCount(): Promise<number> {
+    const queue = await this.getQueue();
+    return queue.length;
+  }
+
+  /**
+   * Subscribe to pending count changes
+   */
+  onPendingCountChange(listener: (count: number) => void): () => void {
+    this.listeners.push(listener);
+    return () => {
+      this.listeners = this.listeners.filter(l => l !== listener);
+    };
+  }
+
+  private notifyListeners(count: number): void {
+    this.listeners.forEach(listener => listener(count));
+  }
+
+  private async checkConnectivity(): Promise<boolean> {
+    try {
+      const state = await Network.getNetworkStateAsync();
+      return state.isConnected && state.isInternetReachable;
+    } catch {
+      return false;
+    }
+  }
+
+  private generateId(): string {
+    return `req_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  }
+}
+
+export const requestQueue = new RequestQueue();
+export default requestQueue;


### PR DESCRIPTION
Close #57 


## Implement Offline Request Queue

### Overview
This PR adds an offline request queue system to handle API requests when the device is offline. Failed requests are queued and automatically retried when connectivity is restored, with a visual indicator showing pending requests.

### Changes Made

#### New Files
- `src/services/api/requestQueue.ts` - Core queue service for managing offline requests
- `src/hooks/usePendingRequests.ts` - Hook to track pending request count

#### Modified Files
- `src/services/api/axios.config.ts` - Added network error handling to queue requests
- `App.tsx` - Initialized queue monitoring on app start
- `src/components/mobile/MobileHeader.tsx` - Added pending requests badge to header

### Features Implemented
- ✅ Queue failed requests when offline
- ✅ Automatic retry when back online (every 10 seconds)
- ✅ Pending requests badge in UI header
- ✅ Persistent queue storage using AsyncStorage
- ✅ Retry limit (3 attempts) with failed request cleanup

### Testing Steps
1. Start the app and disconnect network
2. Perform actions that trigger API calls
3. Verify red badge appears on header bell icon
4. Reconnect network and wait for automatic retry
5. Confirm badge disappears as requests succeed

### Technical Details
- Uses AsyncStorage for queue persistence
- Monitors network status via Expo Network API
- Integrates with existing axios interceptor pattern
- Thread-safe queue processing to prevent concurrent retries