### PR TITLE
feat(auth): add centralized auth service with login, logout, and chec…

### DIFF
--- a/src/__tests__/services/auth.test.ts
+++ b/src/__tests__/services/auth.test.ts
@@ -1,0 +1,209 @@
+import { useAppStore } from '../../store';
+import { login, logout, checkAuthStatus } from '../../services/auth';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('../../services/mobileAuth', () => ({
+  __esModule: true,
+  default: {
+    login: jest.fn(),
+    logout: jest.fn(),
+    restoreSession: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+import mobileAuthService from '../../services/mobileAuth';
+
+const mockMobileAuth = mobileAuthService as jest.Mocked<typeof mobileAuthService>;
+
+const MOCK_USER = { id: 'u1', name: 'Ada Lovelace', email: 'ada@teachlink.com' };
+const MOCK_TOKENS = { accessToken: 'at_abc', refreshToken: 'rt_xyz', expiresAt: Date.now() + 3_600_000 };
+const MOCK_AUTH_RESULT = { user: MOCK_USER, tokens: MOCK_TOKENS };
+
+function getStore() {
+  return useAppStore.getState();
+}
+
+function resetStore() {
+  useAppStore.setState({
+    user: null,
+    isAuthenticated: false,
+    isAuthLoading: false,
+    authError: null,
+    accessToken: null,
+    refreshToken: null,
+    sessionExpiresAt: null,
+    theme: 'light',
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('auth service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetStore();
+  });
+
+  // ── login ──────────────────────────────────────────────────────────────────
+
+  describe('login', () => {
+    it('authenticates the user and syncs state on success', async () => {
+      mockMobileAuth.login.mockResolvedValueOnce(MOCK_AUTH_RESULT);
+
+      await login({ email: 'ada@teachlink.com', password: 'secret123' });
+
+      const state = getStore();
+      expect(state.isAuthenticated).toBe(true);
+      expect(state.user).toEqual(MOCK_USER);
+      expect(state.accessToken).toBe(MOCK_TOKENS.accessToken);
+      expect(state.refreshToken).toBe(MOCK_TOKENS.refreshToken);
+      expect(state.isAuthLoading).toBe(false);
+      expect(state.authError).toBeNull();
+    });
+
+    it('normalises the email before forwarding to mobileAuthService', async () => {
+      mockMobileAuth.login.mockResolvedValueOnce(MOCK_AUTH_RESULT);
+
+      await login({ email: '  ADA@teachLink.com  ', password: 'secret123' });
+
+      expect(mockMobileAuth.login).toHaveBeenCalledWith(
+        expect.objectContaining({ email: 'ada@teachlink.com' }),
+      );
+    });
+
+    it('forwards the rememberMe flag', async () => {
+      mockMobileAuth.login.mockResolvedValueOnce(MOCK_AUTH_RESULT);
+
+      await login({ email: 'ada@teachlink.com', password: 'secret123', rememberMe: true });
+
+      expect(mockMobileAuth.login).toHaveBeenCalledWith(
+        expect.objectContaining({ rememberMe: true }),
+      );
+    });
+
+    it('sets authError and resets loading when the API call fails', async () => {
+      const apiError = new Error('Invalid credentials');
+      mockMobileAuth.login.mockRejectedValueOnce(apiError);
+
+      await expect(login({ email: 'ada@teachlink.com', password: 'wrongpass' })).rejects.toThrow(
+        'Invalid credentials',
+      );
+
+      const state = getStore();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.authError).toBe('Invalid credentials');
+      expect(state.isAuthLoading).toBe(false);
+    });
+
+    describe('input validation', () => {
+      it('throws when email is missing', async () => {
+        await expect(login({ email: '', password: 'secret123' })).rejects.toThrow(
+          'Email is required.',
+        );
+        expect(mockMobileAuth.login).not.toHaveBeenCalled();
+      });
+
+      it('throws when email is malformed', async () => {
+        await expect(login({ email: 'not-an-email', password: 'secret123' })).rejects.toThrow(
+          'valid email address',
+        );
+        expect(mockMobileAuth.login).not.toHaveBeenCalled();
+      });
+
+      it('throws when password is missing', async () => {
+        await expect(login({ email: 'ada@teachlink.com', password: '' })).rejects.toThrow(
+          'Password is required.',
+        );
+        expect(mockMobileAuth.login).not.toHaveBeenCalled();
+      });
+
+      it('throws when password is too short', async () => {
+        await expect(login({ email: 'ada@teachlink.com', password: '123' })).rejects.toThrow(
+          'at least 6 characters',
+        );
+        expect(mockMobileAuth.login).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  // ── logout ─────────────────────────────────────────────────────────────────
+
+  describe('logout', () => {
+    it('clears auth state after a successful logout', async () => {
+      // Seed authenticated state first
+      useAppStore.setState({ user: MOCK_USER, isAuthenticated: true, accessToken: 'at_abc' });
+      mockMobileAuth.logout.mockResolvedValueOnce(undefined);
+
+      await logout();
+
+      const state = getStore();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.user).toBeNull();
+      expect(state.accessToken).toBeNull();
+      expect(state.isAuthLoading).toBe(false);
+    });
+
+    it('still clears local state even when the API call throws', async () => {
+      useAppStore.setState({ user: MOCK_USER, isAuthenticated: true });
+      mockMobileAuth.logout.mockRejectedValueOnce(new Error('Network error'));
+
+      await logout(); // should not throw
+
+      const state = getStore();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.user).toBeNull();
+    });
+  });
+
+  // ── checkAuthStatus ────────────────────────────────────────────────────────
+
+  describe('checkAuthStatus', () => {
+    it('returns true and restores user when a valid session exists', async () => {
+      mockMobileAuth.restoreSession.mockResolvedValueOnce(MOCK_AUTH_RESULT);
+
+      const isAuthenticated = await checkAuthStatus();
+
+      expect(isAuthenticated).toBe(true);
+      const state = getStore();
+      expect(state.isAuthenticated).toBe(true);
+      expect(state.user).toEqual(MOCK_USER);
+      expect(state.isAuthLoading).toBe(false);
+    });
+
+    it('returns false and clears state when no session is found', async () => {
+      mockMobileAuth.restoreSession.mockResolvedValueOnce(null);
+
+      const isAuthenticated = await checkAuthStatus();
+
+      expect(isAuthenticated).toBe(false);
+      const state = getStore();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.user).toBeNull();
+      expect(state.isAuthLoading).toBe(false);
+    });
+
+    it('returns false and clears state when restoreSession throws', async () => {
+      mockMobileAuth.restoreSession.mockRejectedValueOnce(new Error('Storage failure'));
+
+      const isAuthenticated = await checkAuthStatus();
+
+      expect(isAuthenticated).toBe(false);
+      const state = getStore();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.isAuthLoading).toBe(false);
+    });
+  });
+});

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,136 @@
+import { useAppStore } from '../store';
+import logger from '../utils/logger';
+import mobileAuthService from './mobileAuth';
+
+export type { AuthResult, AuthTokens, AuthUser, LoginCredentials } from './mobileAuth';
+
+// ─── Validation helpers ───────────────────────────────────────────────────────
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function validateLoginInput(email: string, password: string): void {
+  if (!email || typeof email !== 'string' || !email.trim()) {
+    throw new Error('Email is required.');
+  }
+  if (!EMAIL_PATTERN.test(email.trim())) {
+    throw new Error('Please enter a valid email address.');
+  }
+  if (!password || typeof password !== 'string') {
+    throw new Error('Password is required.');
+  }
+  if (password.length < 6) {
+    throw new Error('Password must be at least 6 characters.');
+  }
+}
+
+// ─── Auth Service ─────────────────────────────────────────────────────────────
+
+/**
+ * Authenticate a user with email and password.
+ *
+ * Validates credentials locally before hitting the network, then persists
+ * tokens via secureStorage and syncs the resulting user into the global
+ * Zustand store.
+ *
+ * @throws If validation fails or the API returns an error.
+ */
+export async function login(credentials: {
+  email: string;
+  password: string;
+  rememberMe?: boolean;
+}): Promise<void> {
+  const { email, password, rememberMe = false } = credentials;
+
+  validateLoginInput(email, password);
+
+  const store = useAppStore.getState();
+  store.setAuthLoading(true);
+  store.setAuthError(null);
+
+  try {
+    const result = await mobileAuthService.login({
+      email: email.trim().toLowerCase(),
+      password,
+      rememberMe,
+    });
+
+    store.setUser(result.user);
+    store.setTokens(
+      result.tokens.accessToken,
+      result.tokens.refreshToken,
+      result.tokens.expiresAt,
+    );
+
+    logger.info('AuthService: login successful', { userId: result.user.id });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Login failed. Please try again.';
+    store.setAuthError(message);
+    logger.error('AuthService: login failed', error);
+    throw error;
+  } finally {
+    store.setAuthLoading(false);
+  }
+}
+
+/**
+ * Log out the current user.
+ *
+ * Notifies the backend (best-effort), clears all tokens from secure storage,
+ * and resets the auth slice of the global store.
+ */
+export async function logout(): Promise<void> {
+  const store = useAppStore.getState();
+  store.setAuthLoading(true);
+
+  try {
+    await mobileAuthService.logout();
+    store.logout();
+    logger.info('AuthService: logout successful');
+  } catch (error) {
+    // Still reset local state even if the API call fails
+    store.logout();
+    logger.warn('AuthService: logout encountered an error, session cleared locally', error);
+  } finally {
+    store.setAuthLoading(false);
+  }
+}
+
+/**
+ * Determine whether the user has an active authenticated session.
+ *
+ * On app launch, call this to restore a previous session from secure storage
+ * or attempt a silent token refresh. Updates the store accordingly.
+ *
+ * @returns `true` if the user is (or was restored as) authenticated.
+ */
+export async function checkAuthStatus(): Promise<boolean> {
+  const store = useAppStore.getState();
+  store.setAuthLoading(true);
+  store.setAuthError(null);
+
+  try {
+    const session = await mobileAuthService.restoreSession();
+
+    if (!session) {
+      store.logout();
+      logger.info('AuthService: no active session found');
+      return false;
+    }
+
+    store.setUser(session.user);
+    store.setTokens(
+      session.tokens.accessToken,
+      session.tokens.refreshToken,
+      session.tokens.expiresAt,
+    );
+
+    logger.info('AuthService: session restored', { userId: session.user.id });
+    return true;
+  } catch (error) {
+    store.logout();
+    logger.error('AuthService: checkAuthStatus failed', error);
+    return false;
+  } finally {
+    store.setAuthLoading(false);
+  }
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -11,6 +11,8 @@ export interface User {
 interface AppState {
   user: User | null;
   isAuthenticated: boolean;
+  isAuthLoading: boolean;
+  authError: string | null;
   accessToken: string | null;
   refreshToken: string | null;
   sessionExpiresAt: number | null;
@@ -18,12 +20,16 @@ interface AppState {
   setUser: (user: User | null) => void;
   setTheme: (theme: "light" | "dark") => void;
   setTokens: (accessToken: string, refreshToken: string, expiresAt: number) => void;
+  setAuthLoading: (loading: boolean) => void;
+  setAuthError: (error: string | null) => void;
   logout: () => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
   user: null,
   isAuthenticated: false,
+  isAuthLoading: false,
+  authError: null,
   accessToken: null,
   refreshToken: null,
   sessionExpiresAt: null,
@@ -32,10 +38,14 @@ export const useAppStore = create<AppState>((set) => ({
   setTheme: (theme) => set({ theme }),
   setTokens: (accessToken, refreshToken, sessionExpiresAt) =>
     set({ accessToken, refreshToken, sessionExpiresAt }),
+  setAuthLoading: (isAuthLoading) => set({ isAuthLoading }),
+  setAuthError: (authError) => set({ authError }),
   logout: () =>
     set({
       user: null,
       isAuthenticated: false,
+      isAuthLoading: false,
+      authError: null,
       accessToken: null,
       refreshToken: null,
       sessionExpiresAt: null,


### PR DESCRIPTION
## feat(auth): Add Centralized Auth Service

### Summary

Previously, authentication logic was scattered across components with no single module owning login, logout, or session-checking responsibilities. Token storage existed via `secureStorage` and token refresh was handled inside the Axios interceptor, but nothing tied it all together.

This PR introduces a dedicated `auth` service as the single entry point for all authentication operations. It validates inputs, delegates to the existing `mobileAuthService` for low-level token/session management, and keeps the global Zustand store in sync — including new `isAuthLoading` and `authError` state fields for UI feedback.

---

### Changes

- **New auth service** — Exports three public functions:
  - [login(credentials)](cci:1://file:///home/jayking/projects/teachLink_mobile/src/services/auth.ts:27:0-72:1) — Validates email/password locally, authenticates against the API, and updates the store with the returned user and tokens.
  - [logout()](cci:1://file:///home/jayking/projects/teachLink_mobile/src/store/index.ts:42:2-51:6) — Notifies the backend (best-effort), clears secure storage, and resets all auth state in the store.
  - [checkAuthStatus()](cci:1://file:///home/jayking/projects/teachLink_mobile/src/services/auth.ts:97:0-135:1) — Attempts to restore a session from secure storage or silently refresh tokens on app launch; returns a boolean indicating whether the user is authenticated.

- **Input validation** — [login](cci:1://file:///home/jayking/projects/teachLink_mobile/src/services/auth.ts:27:0-72:1) enforces non-empty email, valid email format, and a minimum password length before any network call is made.

- **Global store extended** — Added `isAuthLoading` and `authError` fields (with [setAuthLoading](cci:1://file:///home/jayking/projects/teachLink_mobile/src/store/index.ts:40:2-40:59) / [setAuthError](cci:1://file:///home/jayking/projects/teachLink_mobile/src/store/index.ts:41:2-41:49) setters) so any component can subscribe to in-flight auth state and surface error messages without coupling to the service layer directly.

- **Unit tests** — 13 tests covering: successful login + state sync, email normalisation, `rememberMe` forwarding, API error handling, all four validation error cases, logout with and without network errors, and all three [checkAuthStatus](cci:1://file:///home/jayking/projects/teachLink_mobile/src/services/auth.ts:97:0-135:1) outcomes (valid session / no session / thrown error).

---

### Testing

- Ran the new test suite: **13/13 tests pass**.
- Ran the full test suite to confirm no regressions across existing suites.
- All mocks are isolated per test via `jest.clearAllMocks()` and manual Zustand store resets so tests do not bleed state into one another.

---

Closes #60