### PR TITLE
fix: remove direct console.log and add production stripping

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -29,6 +29,12 @@ if (__DEV__) {
   LogBox.ignoreLogs([
     "Non-serializable values were found in the navigation state",
   ]);
+} else {
+  // Strip all logs except errors in production for performance and security
+  console.log = () => {};
+  console.info = () => {};
+  console.warn = () => {};
+  console.debug = () => {};
 }
 
 export default function App() {

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { crashReportingService } from '../../services/crashReporting';
+import logger from '../../utils/logger';
 
 interface Props {
   children: ReactNode;
@@ -50,13 +51,13 @@ export class ErrorBoundary extends Component<Props, State> {
         componentStack: errorInfo.componentStack,
       });
     } catch (reportingError) {
-      console.error('Error reporting failed:', reportingError);
+      logger.error('Error reporting failed:', reportingError);
     }
 
     // Always log locally as a fallback for development and non-configured monitoring.
-    console.error(`[${boundaryName}] Caught runtime error:`, error.message);
-    console.error(error);
-    console.error(`[${boundaryName}] Component stack:\n${errorInfo.componentStack}`);
+    logger.error(`[${boundaryName}] Caught runtime error:`, error.message);
+    logger.error(error);
+    logger.error(`[${boundaryName}] Component stack:\n${errorInfo.componentStack}`);
 
     this.props.onError?.(error, errorInfo);
     

--- a/src/components/mobile/MobileQuizManager/index.tsx
+++ b/src/components/mobile/MobileQuizManager/index.tsx
@@ -16,6 +16,7 @@ import PrimaryButton from '../../common/PrimaryButton';
 import QuizCarousel from './QuizCarousel';
 import QuizProgress from './QuizProgress';
 import QuizResults from './QuizResults';
+import logger from '../../../utils/logger';
 
 interface MobileQuizManagerProps {
   quiz: Quiz;
@@ -58,7 +59,7 @@ export default function MobileQuizManager({
       await startQuiz(quiz.id, quiz.sectionId, courseId);
       setCurrentView('questions');
     } catch (error) {
-      console.error('Error starting quiz:', error);
+      logger.error('Error starting quiz:', error);
     }
   };
 
@@ -95,7 +96,7 @@ export default function MobileQuizManager({
         }, 2000);
       }
     } catch (error) {
-      console.error('Error completing quiz:', error);
+      logger.error('Error completing quiz:', error);
     }
   }, [quiz, completeQuiz, navigation, course, onBack]);
 

--- a/src/hooks/useCamera.ts
+++ b/src/hooks/useCamera.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import logger from '../utils/logger';
 import * as ImagePicker from 'expo-image-picker';
 
 interface CameraOptions {
@@ -42,7 +43,7 @@ export const useCamera = (options: CameraOptions = {}) => {
         return uri;
       }
     } catch (error) {
-      console.error('[useCamera] takePicture error:', error);
+      logger.error('[useCamera] takePicture error:', error);
     } finally {
       setIsLoading(false);
     }
@@ -68,7 +69,7 @@ export const useCamera = (options: CameraOptions = {}) => {
         return uri;
       }
     } catch (error) {
-      console.error('[useCamera] pickFromLibrary error:', error);
+      logger.error('[useCamera] pickFromLibrary error:', error);
     } finally {
       setIsLoading(false);
     }

--- a/src/hooks/useInAppPurchase.ts
+++ b/src/hooks/useInAppPurchase.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import logger from '../utils/logger';
 import {
   mobilePaymentsService,
   SubscriptionPlan,
@@ -74,7 +75,7 @@ export const useInAppPurchase = (): UseInAppPurchase => {
         setCurrentTier(tier);
         setPurchaseHistory(history);
       } catch (err) {
-        console.error('[useInAppPurchase] init error:', err);
+        logger.error('[useInAppPurchase] init error:', err);
       }
     };
 

--- a/src/hooks/useMemoryMonitor.ts
+++ b/src/hooks/useMemoryMonitor.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { Platform } from 'react-native';
+import logger from '../utils/logger';
 
 interface MemoryMonitorOptions {
     componentId: string;
@@ -25,7 +26,7 @@ export function useMemoryMonitor({
         // Warn if a large list is rendered, especially on Android where memory limits
         // can be stricter. This is a proxy warning.
         if (itemCount > thresholdWarning) {
-            console.warn(
+            logger.warn(
                 `[Memory Monitor] ${componentId}: Rendering ${itemCount} items. ` +
                 `Ensure VirtualList/FlatList is used with appropriate windowSize ` +
                 `to prevent excessive memory consumption.`

--- a/src/hooks/useNotificationPermission.ts
+++ b/src/hooks/useNotificationPermission.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import * as Notifications from 'expo-notifications';
 import * as Device from 'expo-device';
 import { Platform, Linking } from 'react-native';
+import logger from '../utils/logger';
 import {
   registerForPushNotifications,
   registerTokenWithBackend,
@@ -37,14 +38,14 @@ export function useNotificationPermission(): UseNotificationPermissionReturn {
       setPermissionStatus(mappedStatus);
       return mappedStatus;
     } catch (error) {
-      console.error('Error checking notification permission:', error);
+      logger.error('Error checking notification permission:', error);
       return 'undetermined';
     }
   }, [isDevice]);
 
   const requestPermission = useCallback(async (): Promise<boolean> => {
     if (!isDevice) {
-      console.warn('Push notifications require a physical device');
+      logger.warn('Push notifications require a physical device');
       return false;
     }
 
@@ -71,7 +72,7 @@ export function useNotificationPermission(): UseNotificationPermissionReturn {
       setIsLoading(false);
       return false;
     } catch (error) {
-      console.error('Error requesting notification permission:', error);
+      logger.error('Error requesting notification permission:', error);
       setIsLoading(false);
       return false;
     }

--- a/src/navigation/linking.ts
+++ b/src/navigation/linking.ts
@@ -2,6 +2,7 @@ import { LinkingOptions } from '@react-navigation/native';
 import * as Linking from 'expo-linking';
 import * as Notifications from 'expo-notifications';
 import { NotificationData, NotificationType } from '../types/notifications';
+import logger from '../utils/logger';
 
 // Define your navigation param list types
 export type RootStackParamList = {
@@ -142,7 +143,7 @@ export function setupNotificationNavigation(): () => void {
   const subscription = Notifications.addNotificationResponseReceivedListener((response) => {
     // Navigation is handled by the linking config above
     // This is here for any additional side effects
-    console.log('Notification response received:', response);
+    logger.info('Notification response received:', response);
   });
 
   return () => {

--- a/src/services/mobilePayments.ts
+++ b/src/services/mobilePayments.ts
@@ -13,6 +13,7 @@
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { apiService } from './api';
+import logger from '../utils/logger';
 
 // import * as IAP from 'react-native-iap'; // Uncomment after installing
 
@@ -190,7 +191,7 @@ class MobilePaymentsService {
 
       this.isInitialized = true;
     } catch (error) {
-      console.error('[Payments] initialize error:', error);
+      logger.error('[Payments] initialize error:', error);
       throw error;
     }
   }
@@ -212,7 +213,7 @@ class MobilePaymentsService {
       // return storeProducts.map(sp => { ... })
       return SUBSCRIPTION_PLANS.filter((p) => productIds.includes(p.productId));
     } catch (error) {
-      console.error('[Payments] getProducts error:', error);
+      logger.error('[Payments] getProducts error:', error);
       throw error;
     }
   }
@@ -251,7 +252,7 @@ class MobilePaymentsService {
       await this._setTier(plan.tier);
       return record;
     } catch (error) {
-      console.error('[Payments] purchaseSubscription error:', error);
+      logger.error('[Payments] purchaseSubscription error:', error);
       throw error;
     }
   }
@@ -276,7 +277,7 @@ class MobilePaymentsService {
       await this._savePurchaseRecord(record);
       return record;
     } catch (error) {
-      console.error('[Payments] purchaseProduct error:', error);
+      logger.error('[Payments] purchaseProduct error:', error);
       throw error;
     }
   }
@@ -322,7 +323,7 @@ class MobilePaymentsService {
 
       return restoredRecords;
     } catch (error) {
-      console.error('[Payments] restorePurchases error:', error);
+      logger.error('[Payments] restorePurchases error:', error);
       throw error;
     }
   }

--- a/src/services/pushNotifications.ts
+++ b/src/services/pushNotifications.ts
@@ -3,6 +3,7 @@ import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
 import { NotificationData, NotificationType } from '../types/notifications';
+import logger from '../utils/logger';
 
 // Configure how notifications are handled when app is in foreground
 Notifications.setNotificationHandler({
@@ -20,7 +21,7 @@ Notifications.setNotificationHandler({
  */
 export async function registerForPushNotifications(): Promise<string | null> {
   if (!Device.isDevice) {
-    console.warn('Push notifications require a physical device');
+    logger.warn('Push notifications require a physical device');
     return null;
   }
 
@@ -36,7 +37,7 @@ export async function registerForPushNotifications(): Promise<string | null> {
     }
 
     if (finalStatus !== 'granted') {
-      console.warn('Push notification permission not granted');
+      logger.warn('Push notification permission not granted');
       return null;
     }
 
@@ -53,7 +54,7 @@ export async function registerForPushNotifications(): Promise<string | null> {
 
     return token.data;
   } catch (error) {
-    console.error('Error registering for push notifications:', error);
+    logger.error('Error registering for push notifications:', error);
     return null;
   }
 }
@@ -150,10 +151,10 @@ export async function registerTokenWithBackend(token: string): Promise<boolean> 
     // });
     // return response.data.success;
 
-    console.log('Push token registered:', token);
+    logger.info('Push token registered:', token);
     return true;
   } catch (error) {
-    console.error('Error registering token with backend:', error);
+    logger.error('Error registering token with backend:', error);
     return false;
   }
 }
@@ -170,10 +171,10 @@ export async function unregisterTokenFromBackend(token: string): Promise<boolean
     // });
     // return response.data.success;
 
-    console.log('Push token unregistered:', token);
+    logger.info('Push token unregistered:', token);
     return true;
   } catch (error) {
-    console.error('Error unregistering token from backend:', error);
+    logger.error('Error unregistering token from backend:', error);
     return false;
   }
 }

--- a/src/utils/imageCache.ts
+++ b/src/utils/imageCache.ts
@@ -1,4 +1,5 @@
 import { Image } from 'expo-image';
+import logger from './logger';
 
 export class ImageCache {
   /**
@@ -17,14 +18,14 @@ export class ImageCache {
         try {
           return await Image.prefetch(url);
         } catch (e) {
-          console.warn(`Failed to prefetch image: ${url}`, e);
+          logger.warn(`Failed to prefetch image: ${url}`, e);
           return false;
         }
       });
 
       return await Promise.all(promises);
     } catch (e) {
-      console.warn('Error prefetching images', e);
+      logger.warn('Error prefetching images', e);
       return [];
     }
   }
@@ -37,7 +38,7 @@ export class ImageCache {
       await Image.clearMemoryCache();
       await Image.clearDiskCache();
     } catch (e) {
-      console.warn('Failed to clear image cache', e);
+      logger.warn('Failed to clear image cache', e);
     }
   }
 }

--- a/src/utils/notificationHandlers.ts
+++ b/src/utils/notificationHandlers.ts
@@ -1,6 +1,7 @@
 import * as Notifications from 'expo-notifications';
 import { useNotificationStore } from '../store/notificationStore';
 import { NotificationData, NotificationType } from '../types/notifications';
+import logger from './logger';
 
 type NavigationRef = {
   navigate: (screen: string, params?: Record<string, unknown>) => void;
@@ -26,7 +27,7 @@ export function handleNotificationResponse(
   const data = response.notification.request.content.data as unknown as NotificationData | undefined;
 
   if (!data?.type) {
-    console.warn('Notification received without type data');
+    logger.warn('Notification received without type data');
     return;
   }
 
@@ -54,7 +55,7 @@ export function handleNotificationResponse(
       handleCommunityActivity(data);
       break;
     default:
-      console.warn('Unknown notification type:', data.type);
+      logger.warn('Unknown notification type:', data.type);
   }
 }
 
@@ -64,7 +65,7 @@ export function handleNotificationResponse(
  */
 export function handleCourseUpdate(data: NotificationData): void {
   if (!navigationRef?.isReady()) {
-    console.warn('Navigation not ready for course update');
+    logger.warn('Navigation not ready for course update');
     return;
   }
 
@@ -82,7 +83,7 @@ export function handleCourseUpdate(data: NotificationData): void {
  */
 export function handleMessage(data: NotificationData): void {
   if (!navigationRef?.isReady()) {
-    console.warn('Navigation not ready for message');
+    logger.warn('Navigation not ready for message');
     return;
   }
 
@@ -100,7 +101,7 @@ export function handleMessage(data: NotificationData): void {
  */
 export function handleLearningReminder(data: NotificationData): void {
   if (!navigationRef?.isReady()) {
-    console.warn('Navigation not ready for learning reminder');
+    logger.warn('Navigation not ready for learning reminder');
     return;
   }
 
@@ -114,7 +115,7 @@ export function handleLearningReminder(data: NotificationData): void {
  */
 export function handleAchievementUnlock(data: NotificationData): void {
   if (!navigationRef?.isReady()) {
-    console.warn('Navigation not ready for achievement');
+    logger.warn('Navigation not ready for achievement');
     return;
   }
 
@@ -132,7 +133,7 @@ export function handleAchievementUnlock(data: NotificationData): void {
  */
 export function handleCommunityActivity(data: NotificationData): void {
   if (!navigationRef?.isReady()) {
-    console.warn('Navigation not ready for community activity');
+    logger.warn('Navigation not ready for community activity');
     return;
   }
 
@@ -225,7 +226,7 @@ export function parseDeepLink(url: string): NotificationData | null {
         return null;
     }
   } catch (error) {
-    console.error('Error parsing deep link:', error);
+    logger.error('Error parsing deep link:', error);
     return null;
   }
 }


### PR DESCRIPTION
# PR Description
## Overview
This PR addresses issue #92 by removing unsafe `console.log` statements and implementing a centralized logging strategy that strips non-essential logs in production.
## Changes
- **Global Log Stripping**: Added a global override in `App.tsx` to silence `console.log`, `info`, `warn`, and `debug` in production builds.
- **Centralized Logger Migration**: Replaced direct `console.*` calls with the project's `logger` utility in 11 files (including `pushNotifications.ts`, `linking.ts`, and various hooks/components).
- **Socket Service**: Verified `src/services/socket/index.ts` is using the proper logger.
## Verification
- Performed a full project grep to ensure no direct console calls remain in `src` (except in the logger itself).
- Manual code review of all impacted files to ensure proper `logger` imports and level mappings (info/warn/error).
Closes #92 