### PR TITLE
Utilised the config instead of hardcoded fallback

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,1 @@
+export * from './env';

--- a/src/services/api/axios.config.ts
+++ b/src/services/api/axios.config.ts
@@ -2,11 +2,14 @@ import axios, { AxiosError, InternalAxiosRequestConfig } from "axios";
 import logger from "../../utils/logger";
 import { getAccessToken, getRefreshToken, saveTokens } from "../secureStorage";
 import requestQueue from "./requestQueue";
+import { getEnv } from "../../config";
 
 // ─── Client ───────────────────────────────────────────────────────────────────
 
+const baseURL = getEnv("EXPO_PUBLIC_API_BASE_URL");
+
 const apiClient = axios.create({
-  baseURL: process.env.EXPO_PUBLIC_API_BASE_URL || "http://localhost:3000",
+  baseURL,
   timeout: 10000,
   headers: {
     "Content-Type": "application/json",
@@ -90,7 +93,7 @@ apiClient.interceptors.response.use(
         if (!refreshToken) throw new Error("No refresh token");
 
         const { data } = await axios.post(
-          `${process.env.EXPO_PUBLIC_API_BASE_URL || "http://localhost:3000"}/auth/refresh`,
+          `${baseURL}/auth/refresh`,
           { refreshToken },
         );
 

--- a/src/services/socket/index.ts
+++ b/src/services/socket/index.ts
@@ -1,14 +1,13 @@
 import { io, Socket } from "socket.io-client";
 import logger from "../../utils/logger";
+import { getEnv } from "../../config";
 
 class SocketService {
   private socket: Socket | null = null;
 
   connect() {
     if (!this.socket) {
-      // Use Expo's native env vars or fallback
-      const socketUrl =
-        process.env.EXPO_PUBLIC_SOCKET_URL || "ws://localhost:3000";
+      const socketUrl = getEnv("EXPO_PUBLIC_SOCKET_URL");
 
       this.socket = io(socketUrl, {
         transports: ["websocket"],


### PR DESCRIPTION
Closes #93 

- Added a central export for `config`
- Utilised the config instead of hardcoded fallbacks