### PR TITLE
feat: implement useAnalytics hook and integrate automatic screen trac…

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,5 @@
-import { Stack } from "expo-router";
-import React from "react";
+import { Stack, usePathname, useSegments } from "expo-router";
+import React, { useEffect } from "react";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import "react-native-reanimated";
 import "../global.css"; // NativeWind CSS
@@ -7,11 +7,29 @@ import { ErrorBoundary } from '../src/components/common/ErrorBoundary';
 import { AnalyticsProvider } from "../src/components/mobile/AnalyticsProvider";
 import { OfflineIndicatorProvider } from "../src/components/mobile/OfflineIndicatorProvider";
 import { SwipeableNavigation } from '../src/components/mobile/SwipeableNavigation';
+import { useAnalytics } from '../src/hooks/useAnalytics';
+
+// Component to handle auto screen tracking
+function ScreenTracker() {
+  const pathname = usePathname();
+  const segments = useSegments();
+  const { trackScreen } = useAnalytics();
+
+  useEffect(() => {
+    if (pathname) {
+      // Basic screen tracking based on pathname
+      trackScreen(pathname, { segments: segments.join('/') });
+    }
+  }, [pathname, segments, trackScreen]);
+
+  return null;
+}
 
 export default function RootLayout() {
   return (
     <ErrorBoundary boundaryName="RootLayout">
       <AnalyticsProvider>
+        <ScreenTracker />
         <OfflineIndicatorProvider>
         <GestureHandlerRootView style={{ flex: 1 }}>
             <Stack>

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -52,11 +52,49 @@ export const useAnalytics = () => {
     [service]
   );
 
+  /**
+   * Track button clicks
+   */
+  const trackButtonClick = useCallback(
+    (buttonName: string, properties?: EventProperties) => {
+      service.trackEvent(AnalyticsEvent.UI_CLICK, { button: buttonName, ...properties });
+    },
+    [service]
+  );
+
+  /**
+   * Track form submissions
+   */
+  const trackFormSubmit = useCallback(
+    (formName: string, properties?: EventProperties) => {
+      service.trackEvent(AnalyticsEvent.FORM_SUBMIT, { form: formName, ...properties });
+    },
+    [service]
+  );
+
+  /**
+   * Track errors
+   */
+  const trackError = useCallback(
+    (error: Error | string, isFatal: boolean = false, properties?: EventProperties) => {
+      const errorMessage = error instanceof Error ? error.message : error;
+      service.trackEvent(isFatal ? AnalyticsEvent.CRASH_REPORT : AnalyticsEvent.API_ERROR, {
+        error: errorMessage,
+        isFatal,
+        ...properties,
+      });
+    },
+    [service]
+  );
+
   return {
     trackEvent,
     trackScreen,
     trackTiming,
     identify,
+    trackButtonClick,
+    trackFormSubmit,
+    trackError,
     service, // Direct access if needed
   };
 };


### PR DESCRIPTION
#closes #83 

### Description
This PR resolves the issue where the `AnalyticsProvider` was mounted in the root layout but lacked automated and standardized tracking capabilities. It introduces automatic screen view tracking globally across the app and provides a robust set of methods in the `useAnalytics` hook for developers to easily track specific user interactions and errors.

Close #022
Resolves #83

### Changes Made
* **`app/_layout.tsx`**: 
  * Introduced an internal `<ScreenTracker />` component that hooks into `expo-router`'s `usePathname` and `useSegments`.
  * Mounted `<ScreenTracker />` inside `<AnalyticsProvider>` to automatically emit `screen_view` events whenever the navigation route changes.
* **`src/hooks/useAnalytics.ts`**:
  * Added `trackButtonClick(buttonName, properties)` to standardize logging `ui_click` events.
  * Added `trackFormSubmit(formName, properties)` to standardize logging `form_submit` events.
  * Added `trackError(error, isFatal, properties)` to seamlessly capture `api_error` and `crash_report` events.

### Testing Instructions
1. Run the app using `npx expo start`.
2. **Screen Tracking:** Navigate between different tabs and pages (e.g., Home -> Settings -> Profile). Verify in the development console or your analytics dashboard that `screen_view` events are firing with the correct pathname.
3. **Action Tracking:** Integrate `trackButtonClick`, `trackFormSubmit`, or `trackError` on a temporary test screen component and execute those actions. Ensure that `ui_click`, `form_submit`, and error events are successfully dispatched with their respective properties.

### Impacted Files
- `app/_layout.tsx`
- `src/hooks/useAnalytics.ts`

### Labels
`monitoring`, `priority-medium`
