### PR TITLE
feat: integrate voice search into search input (#88)

### DIFF
--- a/app.json
+++ b/app.json
@@ -28,7 +28,8 @@
       "permissions": [
         "RECEIVE_BOOT_COMPLETED",
         "VIBRATE",
-        "WAKE_LOCK"
+        "WAKE_LOCK",
+        "RECORD_AUDIO"
       ]
     },
     "web": {
@@ -59,7 +60,13 @@
           "mode": "production"
         }
       ],
-      "expo-speech-recognition"
+      [
+        "expo-speech-recognition",
+        {
+          "microphonePermission": "Allow TeachLink to use the microphone for voice search.",
+          "speechRecognitionPermission": "Allow TeachLink to use speech recognition for voice search."
+        }
+      ]
     ],
     "notification": {
       "icon": "./assets/notification-icon.png",

--- a/src/components/mobile/MobileSearch.tsx
+++ b/src/components/mobile/MobileSearch.tsx
@@ -9,8 +9,8 @@ import {
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
-import { Search, SlidersHorizontal } from 'lucide-react-native';
-import { VoiceSearch } from './VoiceSearch';
+import { Search, SlidersHorizontal, Mic, Square } from 'lucide-react-native';
+import { useVoiceRecognition } from '../../hooks/useVoiceRecognition';
 import { SearchHistory } from './SearchHistory';
 import { FilterSheet, FilterField, FilterValues } from './FilterSheet';
 import { SearchResultCard, SearchResultItem } from './SearchResultCard';
@@ -95,6 +95,25 @@ export function MobileSearch({
   const [results, setResults] = useState<SearchResultItem[]>([]);
   const [hasSearched, setHasSearched] = useState(false);
 
+  const { isListening, isAvailable, startListening, stopListening, resetTranscript } =
+    useVoiceRecognition({
+      lang: 'en-US',
+      interimResults: true,
+      onResult(text, isFinal) {
+        setQuery(text);
+        if (isFinal && text.trim()) performSearch(text);
+      },
+    });
+
+  const handleVoicePress = useCallback(() => {
+    if (isListening) {
+      stopListening();
+    } else {
+      resetTranscript();
+      startListening();
+    }
+  }, [isListening, startListening, stopListening, resetTranscript]);
+
   const suggestions = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return SUGGESTION_KEYWORDS.slice(0, 5);
@@ -142,14 +161,6 @@ export function MobileSearch({
     [performSearch]
   );
 
-  const handleVoiceResult = useCallback(
-    (text: string) => {
-      setQuery(text);
-      performSearch(text);
-    },
-    [performSearch]
-  );
-
   const handleApplyFilters = useCallback((values: FilterValues) => {
     setFilterValues(values);
     setFilterSheetVisible(false);
@@ -170,8 +181,8 @@ export function MobileSearch({
           <Search size={20} color="#9CA3AF" style={styles.searchIcon} />
           <TextInput
             style={styles.input}
-            placeholder={placeholder}
-            placeholderTextColor="#9CA3AF"
+            placeholder={isListening ? 'Listening...' : placeholder}
+            placeholderTextColor={isListening ? '#19c3e6' : '#9CA3AF'}
             value={query}
             onChangeText={setQuery}
             onFocus={() => setSuggestionsVisible(true)}
@@ -179,12 +190,15 @@ export function MobileSearch({
             onSubmitEditing={handleSubmit}
             returnKeyType="search"
           />
+          {isAvailable && (
+            <TouchableOpacity onPress={handleVoicePress} style={styles.micBtn} accessibilityLabel={isListening ? 'Stop voice search' : 'Start voice search'}>
+              {isListening
+                ? <Square size={18} color="#19c3e6" fill="#19c3e6" />
+                : <Mic size={20} color="#9CA3AF" />}
+            </TouchableOpacity>
+          )}
         </View>
         <View style={styles.actions}>
-          <VoiceSearch
-            onTranscript={setQuery}
-            onTranscriptFinal={handleVoiceResult}
-          />
           <TouchableOpacity
             onPress={() => setFilterSheetVisible(true)}
             style={[styles.filterBtn, Object.keys(filterValues).length > 0 && styles.filterBtnActive]}
@@ -282,6 +296,11 @@ const styles = StyleSheet.create({
     color: '#111827',
     paddingVertical: 12,
     paddingRight: 12,
+  },
+  micBtn: {
+    padding: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   actions: {
     flexDirection: 'row',

--- a/src/components/mobile/MobileSearch.tsx
+++ b/src/components/mobile/MobileSearch.tsx
@@ -9,8 +9,8 @@ import {
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
-import { Search, SlidersHorizontal, Mic, Square } from 'lucide-react-native';
-import { useVoiceRecognition } from '../../hooks/useVoiceRecognition';
+import { Search, SlidersHorizontal } from 'lucide-react-native';
+import { VoiceSearch } from './VoiceSearch';
 import { SearchHistory } from './SearchHistory';
 import { FilterSheet, FilterField, FilterValues } from './FilterSheet';
 import { SearchResultCard, SearchResultItem } from './SearchResultCard';
@@ -94,25 +94,7 @@ export function MobileSearch({
   const [filterValues, setFilterValues] = useState<FilterValues>({});
   const [results, setResults] = useState<SearchResultItem[]>([]);
   const [hasSearched, setHasSearched] = useState(false);
-
-  const { isListening, isAvailable, startListening, stopListening, resetTranscript } =
-    useVoiceRecognition({
-      lang: 'en-US',
-      interimResults: true,
-      onResult(text, isFinal) {
-        setQuery(text);
-        if (isFinal && text.trim()) performSearch(text);
-      },
-    });
-
-  const handleVoicePress = useCallback(() => {
-    if (isListening) {
-      stopListening();
-    } else {
-      resetTranscript();
-      startListening();
-    }
-  }, [isListening, startListening, stopListening, resetTranscript]);
+  const [isListening, setIsListening] = useState(false);
 
   const suggestions = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -190,13 +172,18 @@ export function MobileSearch({
             onSubmitEditing={handleSubmit}
             returnKeyType="search"
           />
-          {isAvailable && (
-            <TouchableOpacity onPress={handleVoicePress} style={styles.micBtn} accessibilityLabel={isListening ? 'Stop voice search' : 'Start voice search'}>
-              {isListening
-                ? <Square size={18} color="#19c3e6" fill="#19c3e6" />
-                : <Mic size={20} color="#9CA3AF" />}
-            </TouchableOpacity>
-          )}
+          <VoiceSearch
+            compact
+            onTranscript={(text) => {
+              setQuery(text);
+              setIsListening(true);
+            }}
+            onTranscriptFinal={(text) => {
+              setQuery(text);
+              setIsListening(false);
+              performSearch(text);
+            }}
+          />
         </View>
         <View style={styles.actions}>
           <TouchableOpacity
@@ -296,11 +283,6 @@ const styles = StyleSheet.create({
     color: '#111827',
     paddingVertical: 12,
     paddingRight: 12,
-  },
-  micBtn: {
-    padding: 10,
-    justifyContent: 'center',
-    alignItems: 'center',
   },
   actions: {
     flexDirection: 'row',

--- a/src/components/mobile/VoiceSearch.tsx
+++ b/src/components/mobile/VoiceSearch.tsx
@@ -15,6 +15,7 @@ export function VoiceSearch({
   onTranscript,
   onTranscriptFinal,
   disabled = false,
+  compact = false,
 }: VoiceSearchProps) {
   const {
     isListening,
@@ -52,6 +53,22 @@ export function VoiceSearch({
       startListening();
     }
   };
+
+  if (compact) {
+    return (
+      <TouchableOpacity
+        onPress={handlePress}
+        disabled={disabled}
+        style={[styles.micBtn, disabled && styles.buttonDisabled]}
+        accessibilityLabel={isListening ? 'Stop voice search' : 'Start voice search'}
+        activeOpacity={0.8}
+      >
+        {isListening
+          ? <Square size={18} color="#19c3e6" fill="#19c3e6" />
+          : <Mic size={20} color="#9CA3AF" />}
+      </TouchableOpacity>
+    );
+  }
 
   return (
     <View style={styles.wrapper}>
@@ -143,5 +160,10 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: '#0369A1',
     flex: 1,
+  },
+  micBtn: {
+    padding: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 });

--- a/src/components/mobile/VoiceSearch.tsx
+++ b/src/components/mobile/VoiceSearch.tsx
@@ -7,6 +7,8 @@ export interface VoiceSearchProps {
   onTranscript: (text: string) => void;
   onTranscriptFinal?: (text: string) => void;
   disabled?: boolean;
+  /** Renders a compact mic-only icon button for inline use inside a search input */
+  compact?: boolean;
 }
 
 export function VoiceSearch({


### PR DESCRIPTION
- Add mic button inside search TextInput in MobileSearch
- Wire useVoiceRecognition directly: interim results update query live, final result triggers performSearch automatically
- Mic icon toggles to stop (square) while listening; placeholder shows 'Listening...' in brand colour for visual feedback
- Button only renders when isAvailable (degrades gracefully in Expo Go)
- Add RECORD_AUDIO to android permissions in app.json
- Add microphonePermission + speechRecognitionPermission strings to expo-speech-recognition plugin config for proper iOS/Android prompts

Close #027