### PR TITLE
ci: add build verification for Android and iOS (#123)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,109 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  # ── JS-level build verification ──────────────────────────────────────────────
+  # Runs on Linux: bundles JS for both platforms and checks TypeScript types.
+  # Catches import errors, type errors, and broken module resolution without
+  # requiring native toolchains.
+  build:
+    name: Build Verification (JS bundles + TypeScript)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: TypeScript type check
+        run: npx tsc --noEmit
+
+      - name: Verify Android bundle
+        run: npx expo export --platform android
+
+      - name: Verify iOS bundle
+        run: npx expo export --platform ios
+
+  # ── Android native build ──────────────────────────────────────────────────────
+  # Prebuilds the managed Expo project into a native Android project and
+  # assembles a debug APK to confirm the native build is not broken.
+  build-android:
+    name: Android Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate native Android project
+        run: npx expo prebuild --platform android --no-install
+
+      - name: Make Gradle wrapper executable
+        run: chmod +x android/gradlew
+
+      - name: Assemble Android debug APK
+        working-directory: android
+        run: ./gradlew assembleDebug --no-daemon
+
+  # ── iOS native build ──────────────────────────────────────────────────────────
+  # Prebuilds the managed Expo project into a native iOS project and compiles
+  # for the iOS Simulator (no code signing required).
+  # Only runs on macOS where Xcode is available.
+  build-ios:
+    name: iOS Build
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate native iOS project
+        run: npx expo prebuild --platform ios --no-install
+
+      - name: Install CocoaPods
+        working-directory: ios
+        run: pod install
+
+      - name: Build iOS (simulator, no code signing)
+        run: |
+          WORKSPACE=$(find ios -maxdepth 1 -name "*.xcworkspace" | head -1)
+          SCHEME=$(basename "$WORKSPACE" .xcworkspace)
+          xcodebuild \
+            -workspace "$WORKSPACE" \
+            -scheme "$SCHEME" \
+            -configuration Debug \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath /tmp/DerivedData \
+            CODE_SIGNING_ALLOWED=NO \
+            build


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` with three jobs that together satisfy the build verification requirements from issue #123
- **Build (JS bundles + TypeScript)** — runs on `ubuntu-latest`: type-checks with `tsc --noEmit`, then exports the Android and iOS JavaScript bundles via `expo export`. Catches broken imports, missing modules, and type errors without requiring native toolchains.
- **Android Build** — runs on `ubuntu-latest`: uses `expo prebuild` to generate the native Android project, then assembles a debug APK via Gradle to confirm the Android native build is not broken.
- **iOS Build** — runs on `macos-latest` where Xcode is available: uses `expo prebuild` to generate the native iOS project, installs CocoaPods, then compiles for the iOS Simulator with `xcodebuild` (no code signing required).

## Test plan

- [ ] Confirm the `CI` workflow appears under the Actions tab after merge
- [ ] Verify the `Build Verification` job passes on a PR against `main`
- [ ] Verify the `Android Build` job produces a debug APK without errors
- [ ] Verify the `iOS Build` job compiles successfully on the `macos-latest` runner
- [ ] Confirm a PR that introduces a TypeScript error is caught by the type-check step
- [ ] Confirm a PR that breaks an import is caught by the `expo export` step

Close #123