### PR TITLE
feat: add API cache strategy with stale-while-revalidate

### DIFF
--- a/src/services/api/cache.ts
+++ b/src/services/api/cache.ts
@@ -1,0 +1,81 @@
+interface CacheEntry<T> {
+  data: T;
+  cachedAt: number;
+  ttl: number;       // ms until stale
+  staleTtl: number;  // ms until evicted (stale-while-revalidate window)
+}
+
+const store = new Map<string, CacheEntry<unknown>>();
+
+function isStale<T>(entry: CacheEntry<T>): boolean {
+  return Date.now() - entry.cachedAt > entry.ttl;
+}
+
+function isExpired<T>(entry: CacheEntry<T>): boolean {
+  return Date.now() - entry.cachedAt > entry.staleTtl;
+}
+
+export function getCache<T>(key: string): T | null {
+  const entry = store.get(key) as CacheEntry<T> | undefined;
+  if (!entry || isExpired(entry)) return null;
+  return entry.data;
+}
+
+export function isStaleCache(key: string): boolean {
+  const entry = store.get(key);
+  if (!entry) return false;
+  return isStale(entry);
+}
+
+export function setCache<T>(
+  key: string,
+  data: T,
+  ttl: number,
+  staleTtl: number,
+): void {
+  store.set(key, { data, cachedAt: Date.now(), ttl, staleTtl });
+}
+
+export function invalidateCache(key: string): void {
+  store.delete(key);
+}
+
+export function clearCache(): void {
+  store.clear();
+}
+
+/**
+ * Stale-while-revalidate fetch helper.
+ *
+ * - Returns cached data immediately if available (even if stale).
+ * - Triggers a background revalidation when the entry is stale.
+ * - Falls back to a fresh fetch when no cache entry exists.
+ *
+ * @param key       Cache key
+ * @param fetcher   Async function that fetches fresh data
+ * @param ttl       Time (ms) before data is considered stale (default 60 s)
+ * @param staleTtl  Time (ms) before stale data is evicted (default 5 min)
+ */
+export async function fetchWithSWR<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  ttl = 60_000,
+  staleTtl = 300_000,
+): Promise<T> {
+  const cached = getCache<T>(key);
+
+  if (cached !== null) {
+    if (isStaleCache(key)) {
+      // Revalidate in the background; return stale data now
+      fetcher()
+        .then((fresh) => setCache(key, fresh, ttl, staleTtl))
+        .catch(() => {/* keep stale data on error */});
+    }
+    return cached;
+  }
+
+  // No cache – fetch synchronously
+  const fresh = await fetcher();
+  setCache(key, fresh, ttl, staleTtl);
+  return fresh;
+}

--- a/src/services/api/courseApi.ts
+++ b/src/services/api/courseApi.ts
@@ -1,0 +1,38 @@
+import { Course } from "../../types/course";
+import apiClient from "./axios.config";
+import { fetchWithSWR, invalidateCache } from "./cache";
+
+const COURSES_KEY = "courses:list";
+const courseKey = (id: string) => `courses:${id}`;
+
+// 2 min fresh, 10 min stale window
+const TTL = 2 * 60_000;
+const STALE_TTL = 10 * 60_000;
+
+export const courseApi = {
+  getCourses(): Promise<Course[]> {
+    return fetchWithSWR(
+      COURSES_KEY,
+      () => apiClient.get<Course[]>("/courses").then((r) => r.data),
+      TTL,
+      STALE_TTL,
+    );
+  },
+
+  getCourse(id: string): Promise<Course> {
+    return fetchWithSWR(
+      courseKey(id),
+      () => apiClient.get<Course>(`/courses/${id}`).then((r) => r.data),
+      TTL,
+      STALE_TTL,
+    );
+  },
+
+  invalidateCourses(): void {
+    invalidateCache(COURSES_KEY);
+  },
+
+  invalidateCourse(id: string): void {
+    invalidateCache(courseKey(id));
+  },
+};

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -8,4 +8,8 @@ export const apiService = {
   delete: (url: string) => apiClient.delete(url),
 };
 
+export { courseApi } from "./courseApi";
+export { userApi } from "./userApi";
+export { fetchWithSWR, invalidateCache, clearCache } from "./cache";
+
 export default apiService;

--- a/src/services/api/userApi.ts
+++ b/src/services/api/userApi.ts
@@ -1,0 +1,24 @@
+import { User } from "../../store";
+import apiClient from "./axios.config";
+import { fetchWithSWR, invalidateCache } from "./cache";
+
+const userKey = (id: string) => `users:${id}`;
+
+// 5 min fresh, 15 min stale window
+const TTL = 5 * 60_000;
+const STALE_TTL = 15 * 60_000;
+
+export const userApi = {
+  getUser(id: string): Promise<User> {
+    return fetchWithSWR(
+      userKey(id),
+      () => apiClient.get<User>(`/users/${id}`).then((r) => r.data),
+      TTL,
+      STALE_TTL,
+    );
+  },
+
+  invalidateUser(id: string): void {
+    invalidateCache(userKey(id));
+  },
+};


### PR DESCRIPTION
## Summary
Implements issue #142 — no caching for API responses.

### Changes
- `src/services/api/cache.ts` — in-memory TTL cache with `fetchWithSWR` helper (stale-while-revalidate pattern)
- `src/services/api/courseApi.ts` — cached course list & single-course endpoints (2 min TTL / 10 min stale window)
- `src/services/api/userApi.ts` — cached user profile endpoint (5 min TTL / 15 min stale window)
- `src/services/api/index.ts` — exports new modules alongside existing `apiService`

### How it works
- Fresh cache hit → returned immediately, no network call
- Stale cache hit → stale data returned immediately, background revalidation triggered
- Cache miss → fetch blocks, result stored

Close #142