### PR TITLE
feat(analytics): implement event tracking across screens and components

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,5 +1,3 @@
-import { CourseCardSkeleton, Skeleton, AppText as Text } from "@/src/components";
-import { useDynamicFontSize } from "@/src/hooks";
 import { useRouter } from "expo-router";
 import { useEffect } from "react";
 import {
@@ -10,13 +8,21 @@ import {
   View,
 } from "react-native";
 
+import { CourseCardSkeleton, Skeleton, AppText as Text } from "@/src/components";
 import { sampleCourse } from "@/src/data/sampleCourse";
+import { useDynamicFontSize , useAnalytics } from "@/src/hooks";
 import { useAppStore } from "@/src/store";
+import { AnalyticsEvent, ScreenName } from "@/src/utils/trackingEvents";
 
 export default function HomeScreen() {
   const router = useRouter();
   const { isLoading, setLoading } = useAppStore();
   const { scale } = useDynamicFontSize();
+  const { trackEvent, trackScreen } = useAnalytics();
+
+  useEffect(() => {
+    trackScreen(ScreenName.HOME);
+  }, []);
 
   const fetchHomeData = () => {
     setLoading(true);
@@ -84,12 +90,13 @@ export default function HomeScreen() {
       {/* Course Viewer Button - Primary */}
       <TouchableOpacity
         style={styles.primaryButton}
-        onPress={() =>
+        onPress={() => {
+          trackEvent(AnalyticsEvent.BUTTON_CLICK, { button: 'start_learning', screen: 'home' });
           router.push({
             pathname: "../course-viewer",
             params: { course: JSON.stringify(sampleCourse) },
-          })
-        }
+          });
+        }}
         accessibilityRole="button"
         accessibilityLabel="Start Learning"
         accessibilityHint="Opens the course viewer with a sample lesson"
@@ -105,7 +112,10 @@ export default function HomeScreen() {
 
       <TouchableOpacity
         style={styles.secondaryButton}
-        onPress={() => router.push("../search")}
+        onPress={() => {
+          trackEvent(AnalyticsEvent.BUTTON_CLICK, { button: 'search', screen: 'home' });
+          router.push("../search");
+        }}
         accessibilityRole="button"
         accessibilityLabel="Search courses"
         accessibilityHint="Navigates to the search screen"
@@ -126,7 +136,10 @@ export default function HomeScreen() {
         {/* Profile Button */}
         <TouchableOpacity
           style={styles.secondaryButton}
-          onPress={() => router.push("../profile/123")}
+          onPress={() => {
+            trackEvent(AnalyticsEvent.BUTTON_CLICK, { button: 'profile', screen: 'home' });
+            router.push("../profile/123");
+          }}
           accessibilityRole="button"
           accessibilityLabel="My Profile"
           accessibilityHint="View your learning progress and achievements"
@@ -143,7 +156,10 @@ export default function HomeScreen() {
 
         <TouchableOpacity
           style={styles.secondaryButton}
-          onPress={() => router.push("../settings")}
+          onPress={() => {
+            trackEvent(AnalyticsEvent.BUTTON_CLICK, { button: 'settings', screen: 'home' });
+            router.push("../settings");
+          }}
           accessibilityRole="button"
           accessibilityLabel="Settings"
           accessibilityHint="Customize your app experience"

--- a/src/components/mobile/MobileCourseViewer.tsx
+++ b/src/components/mobile/MobileCourseViewer.tsx
@@ -10,18 +10,21 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import { AppText as Text } from "../common/AppText";
-import { useDynamicFontSize } from "../../hooks/useDynamicFontSize";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useCourseProgress } from "../../hooks/useCourseProgress";
-import { RootStackParamList } from "../../navigation/types";
-import { Course, Lesson, Note } from "../../types/course";
-import logger from "../../utils/logger";
-import { ErrorBoundary } from "../common/ErrorBoundary";
-import PrimaryButton from "../common/PrimaryButton";
+
 import BookmarkButton from "./BookmarkButton";
 import LessonCarousel from "./LessonCarousel";
 import MobileSyllabus from "./MobileSyllabus";
+import { useAnalytics } from "../../hooks/useAnalytics";
+import { useCourseProgress } from "../../hooks/useCourseProgress";
+import { useDynamicFontSize } from "../../hooks/useDynamicFontSize";
+import { RootStackParamList } from "../../navigation/types";
+import { Course, Lesson, Note } from "../../types/course";
+import logger from "../../utils/logger";
+import { AnalyticsEvent, ScreenName } from "../../utils/trackingEvents";
+import { AppText as Text } from "../common/AppText";
+import { ErrorBoundary } from "../common/ErrorBoundary";
+import PrimaryButton from "../common/PrimaryButton";
 
 /**
  * Props for the MobileCourseViewer component
@@ -49,6 +52,7 @@ export default function MobileCourseViewer({
   navigation,
 }: MobileCourseViewerProps) {
   const { scale } = useDynamicFontSize();
+  const { trackEvent, trackScreen } = useAnalytics();
   const [viewMode, setViewMode] = useState<ViewMode>(
     initialViewMode || "lesson",
   );
@@ -149,10 +153,26 @@ export default function MobileCourseViewer({
       logger.component("MobileCourseViewer", "Mounted", {
         courseId: course.id,
       });
+      trackScreen(ScreenName.COURSE_VIEWER, { courseId: course.id });
+      trackEvent(AnalyticsEvent.COURSE_STARTED, { courseId: course.id, courseTitle: course.title });
     } catch (error) {
       logger.error("Error in MobileCourseViewer:", error);
     }
   }, [course.id]);
+
+  // Track course completion
+  useEffect(() => {
+    if (progress) {
+      const overallProgress = calculateOverallProgress();
+      if (overallProgress >= 100) {
+        trackEvent(AnalyticsEvent.COURSE_COMPLETED, { 
+          courseId: course.id, 
+          courseTitle: course.title,
+          progress: overallProgress 
+        });
+      }
+    }
+  }, [progress, course.id, course.title, calculateOverallProgress, trackEvent]);
 
   const handleLessonChange = useCallback(
     async (lessonId: string, index: number) => {

--- a/src/components/mobile/MobileQuizManager/index.tsx
+++ b/src/components/mobile/MobileQuizManager/index.tsx
@@ -1,3 +1,4 @@
+import { LinearGradient } from 'expo-linear-gradient';
 import React, { useEffect, useState, useCallback } from 'react';
 import {
   View,
@@ -7,15 +8,17 @@ import {
   StyleSheet,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { LinearGradient } from 'expo-linear-gradient';
-import { Quiz, Course } from '../../../types/course';
-import { QuizNavigationProp } from '../../../navigation/types';
-import { useQuizStore } from '../../../store/quizStore';
-import PrimaryButton from '../../common/PrimaryButton';
+
 import QuizCarousel from './QuizCarousel';
 import QuizProgress from './QuizProgress';
 import QuizResults from './QuizResults';
+import { useAnalytics } from '../../../hooks/useAnalytics';
+import { QuizNavigationProp } from '../../../navigation/types';
+import { useQuizStore } from '../../../store/quizStore';
+import { Quiz, Course } from '../../../types/course';
 import logger from '../../../utils/logger';
+import { AnalyticsEvent, ScreenName } from '../../../utils/trackingEvents';
+import PrimaryButton from '../../common/PrimaryButton';
 
 interface MobileQuizManagerProps {
   quiz: Quiz;
@@ -48,16 +51,18 @@ export default function MobileQuizManager({
 
   const [currentView, setCurrentView] = useState<QuizView>('intro');
   const [quizResults, setQuizResults] = useState<{ score: number; passed: boolean } | null>(null);
+  const { trackEvent, trackScreen } = useAnalytics();
 
   useEffect(() => {
     loadQuizProgress(courseId);
-    // Always start with intro screen
+    trackScreen(ScreenName.QUIZ, { quizId: quiz.id, courseId });
     setCurrentView('intro');
   }, [courseId, loadQuizProgress]);
 
   const handleStartQuiz = async () => {
     try {
       await startQuiz(quiz.id, quiz.sectionId, courseId);
+      trackEvent(AnalyticsEvent.QUIZ_STARTED, { quizId: quiz.id, courseId });
       setCurrentView('questions');
     } catch (error) {
       logger.error('Error starting quiz:', error);
@@ -80,6 +85,7 @@ export default function MobileQuizManager({
       const results = await completeQuiz(quiz);
       setQuizResults(results);
       setCurrentView('results');
+      trackEvent(AnalyticsEvent.QUIZ_COMPLETED, { quizId: quiz.id, courseId, score: results.score, passed: results.passed });
       
       // If passed, navigate back to course with syllabus view
       if (results.passed && navigation && course) {
@@ -138,7 +144,7 @@ export default function MobileQuizManager({
           </View>
           <Text style={styles.title}>{quiz.title}</Text>
           <Text style={styles.subtitle}>
-            Test your knowledge and see how well you've mastered this section
+            Test your knowledge and see how well you&apos;ve mastered this section
           </Text>
         </View>
 

--- a/src/components/mobile/MobileSearch.tsx
+++ b/src/components/mobile/MobileSearch.tsx
@@ -1,3 +1,4 @@
+import { Search, SlidersHorizontal } from 'lucide-react-native';
 import React, { useCallback, useMemo, useState } from 'react';
 import {
   View,
@@ -9,17 +10,19 @@ import {
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
-import { AppText as Text } from '../common/AppText';
+
+import { FilterSheet, FilterField, FilterValues } from './FilterSheet';
+import { SearchHistory } from './SearchHistory';
+import { SearchResultCard, SearchResultItem } from './SearchResultCard';
+import { VoiceSearch } from './VoiceSearch';
+import { sampleCourse } from '../../data/sampleCourse';
+import { useAnalytics } from '../../hooks/useAnalytics';
 import { useDynamicFontSize } from '../../hooks/useDynamicFontSize';
 import { useMemoryMonitor } from '../../hooks/useMemoryMonitor';
-import { Search, SlidersHorizontal } from 'lucide-react-native';
-import { VoiceSearch } from './VoiceSearch';
-import { SearchHistory } from './SearchHistory';
-import { FilterSheet, FilterField, FilterValues } from './FilterSheet';
-import { SearchResultCard, SearchResultItem } from './SearchResultCard';
-import { addToSearchHistory } from '../../utils/searchHistory';
-import { sampleCourse } from '../../data/sampleCourse';
 import { Course } from '../../types/course';
+import { addToSearchHistory } from '../../utils/searchHistory';
+import { AnalyticsEvent } from '../../utils/trackingEvents';
+import { AppText as Text } from '../common/AppText';
 
 const DEFAULT_FILTERS: FilterField[] = [
   {
@@ -87,10 +90,10 @@ export interface MobileSearchProps {
   placeholder?: string;
 }
 
-export function MobileSearch({
+export const MobileSearch = ({
   onResultPress,
   placeholder = 'Search courses...',
-}: MobileSearchProps) {
+}: MobileSearchProps) => {
   const [query, setQuery] = useState('');
   const [suggestionsVisible, setSuggestionsVisible] = useState(false);
   const [filterSheetVisible, setFilterSheetVisible] = useState(false);
@@ -98,6 +101,7 @@ export function MobileSearch({
   const [results, setResults] = useState<SearchResultItem[]>([]);
   const [hasSearched, setHasSearched] = useState(false);
   const { scale } = useDynamicFontSize();
+  const { trackEvent } = useAnalytics();
 
   useMemoryMonitor({ componentId: 'MobileSearch', itemCount: results.length });
 
@@ -118,6 +122,7 @@ export function MobileSearch({
         return;
       }
       addToSearchHistory(trimmed);
+      trackEvent(AnalyticsEvent.SEARCH_QUERY, { query: trimmed, filters: filterValues });
       const filtered = filterCourse(sampleCourse, trimmed, filterValues)
         ? [courseToSearchResult(sampleCourse)]
         : [];
@@ -125,7 +130,7 @@ export function MobileSearch({
       setHasSearched(true);
       setSuggestionsVisible(false);
     },
-    [filterValues]
+    [filterValues, trackEvent]
   );
 
   const handleSubmit = useCallback(() => {

--- a/src/utils/trackingEvents.ts
+++ b/src/utils/trackingEvents.ts
@@ -18,10 +18,21 @@ export enum AnalyticsEvent {
   AUTH_LOGOUT = 'auth_logout',
   SEARCH_QUERY = 'search_query',
 
+  // Course Events
+  COURSE_STARTED = 'course_started',
+  COURSE_COMPLETED = 'course_completed',
+
+  // Quiz Events
+  QUIZ_STARTED = 'quiz_started',
+  QUIZ_COMPLETED = 'quiz_completed',
+
   // Content Interaction
   CONTENT_VIEW = 'content_view',
   CONTENT_SHARE = 'content_share',
   CONTENT_LIKE = 'content_like',
+
+  // Button Clicks
+  BUTTON_CLICK = 'button_click',
 
   // Performance & Infrastructure
   PERFORMANCE_METRIC = 'performance_metric',
@@ -48,6 +59,9 @@ export enum ScreenName {
   CONTENT_DETAIL = 'content_detail',
   LOGIN = 'login',
   SIGNUP = 'signup',
+  COURSE_VIEWER = 'course_viewer',
+  QUIZ = 'quiz',
+  SEARCH = 'search',
 }
 
 /**


### PR DESCRIPTION
closes #84 
- Add COURSE_STARTED, COURSE_COMPLETED, QUIZ_STARTED, QUIZ_COMPLETED, BUTTON_CLICK to AnalyticsEvent enum
- Add COURSE_VIEWER, QUIZ, SEARCH to ScreenName enum
- Track screen_view on HomeScreen mount
- Track button_click on all home screen navigation buttons
- Track course_started on MobileCourseViewer mount and course_completed when overall progress reaches 100%
- Track quiz_started in handleStartQuiz and quiz_completed in handleSubmitQuiz with score and passed result properties
- Track search_query in MobileSearch.performSearch with query and filters