### PR TITLE
fix(bookmarks): wire up bookmark saving, sync, and list display

### DIFF
--- a/src/components/mobile/BookmarkButton.tsx
+++ b/src/components/mobile/BookmarkButton.tsx
@@ -1,89 +1,57 @@
 import React from 'react';
 import { TouchableOpacity, Text, ActivityIndicator, View, StyleSheet } from 'react-native';
 
-/**
- * Props for the BookmarkButton component
- */
+import { useBookmarkStore, BookmarkItem } from '../../store/bookmarkStore';
+
 interface BookmarkButtonProps {
-  /** Whether the item is currently bookmarked */
-  isBookmarked: boolean;
-  /** Callback when the bookmark toggle is pressed */
-  onToggle: () => void;
-  /** Whether the button is in a loading state */
-  isLoading?: boolean;
-  /** Size variant of the button */
+  item: BookmarkItem;
   size?: 'small' | 'medium' | 'large';
-  /** Whether to show the label text */
   showLabel?: boolean;
 }
 
-export default function BookmarkButton({
-  isBookmarked,
-  onToggle,
-  isLoading = false,
-  size = 'medium',
-  showLabel = true,
-}: BookmarkButtonProps) {
+export default function BookmarkButton({ item, size = 'medium', showLabel = true }: BookmarkButtonProps) {
+  const { isBookmarked, addBookmark, removeBookmark, isLoading } = useBookmarkStore();
+  const bookmarked = isBookmarked(item.itemId);
+
   const sizeConfig = {
     small: { iconSize: 18, padding: 8 },
     medium: { iconSize: 24, padding: 12 },
     large: { iconSize: 32, padding: 16 },
   };
-
   const config = sizeConfig[size];
 
-  const backgroundColor = isBookmarked 
-    ? '#fef3c7' // yellow-50
-    : '#f3f4f6'; // gray-100
+  const handleToggle = async () => {
+    if (bookmarked) {
+      await removeBookmark(item.itemId);
+    } else {
+      await addBookmark(item);
+    }
+  };
 
-  const borderColor = isBookmarked
-    ? '#facc15' // yellow-400
-    : '#d1d5db'; // gray-300
-
-  const textColor = isBookmarked
-    ? '#b45309' // yellow-700
-    : '#4b5563'; // gray-600
-
-  const iconColor = isBookmarked
-    ? '#eab308' // yellow-500
-    : '#9ca3af'; // gray-400
+  const backgroundColor = bookmarked ? '#fef3c7' : '#f3f4f6';
+  const borderColor = bookmarked ? '#facc15' : '#d1d5db';
+  const textColor = bookmarked ? '#b45309' : '#4b5563';
 
   return (
     <TouchableOpacity
-      onPress={onToggle}
+      testID="bookmark-button"
+      onPress={handleToggle}
       disabled={isLoading}
       activeOpacity={0.7}
       accessibilityRole="button"
-      accessibilityLabel={isBookmarked ? 'Remove bookmark' : 'Add bookmark'}
-      accessibilityHint="Double tap to toggle lesson bookmark status"
-      accessibilityState={{ disabled: isLoading, selected: isBookmarked, busy: isLoading }}
-      style={[
-        styles.button,
-        {
-          backgroundColor,
-          borderColor,
-          borderWidth: 2,
-          padding: config.padding,
-          borderRadius: 24,
-          opacity: isLoading ? 0.5 : 1,
-        },
-      ]}
+      accessibilityLabel={bookmarked ? 'Remove bookmark' : 'Add bookmark'}
+      accessibilityHint="Double tap to toggle bookmark"
+      accessibilityState={{ disabled: isLoading, selected: bookmarked, busy: isLoading }}
+      style={[styles.button, { backgroundColor, borderColor, padding: config.padding, opacity: isLoading ? 0.5 : 1 }]}
     >
       {isLoading ? (
-        <ActivityIndicator color={isBookmarked ? '#F59E0B' : '#19c3e6'} size="small" />
+        <ActivityIndicator color={bookmarked ? '#F59E0B' : '#19c3e6'} size="small" />
       ) : (
         <View style={styles.content}>
-          <Text style={{ fontSize: config.iconSize }}>
-            {isBookmarked ? '⭐' : '☆'}
-          </Text>
+          <Text style={{ fontSize: config.iconSize }}>{bookmarked ? '⭐' : '☆'}</Text>
           {showLabel && (
-            <Text
-              style={[
-                styles.label,
-                { color: textColor, marginLeft: 8 },
-              ]}
-            >
-              {isBookmarked ? 'Bookmarked' : 'Bookmark'}
+            <Text style={[styles.label, { color: textColor }]}>
+              {bookmarked ? 'Bookmarked' : 'Bookmark'}
             </Text>
           )}
         </View>
@@ -97,14 +65,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
+    borderWidth: 2,
+    borderRadius: 24,
   },
-  content: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  label: {
-    fontWeight: '700',
-    fontSize: 14,
-  },
+  content: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center' },
+  label: { fontWeight: '700', fontSize: 14, marginLeft: 8 },
 });

--- a/src/components/mobile/BookmarkList.tsx
+++ b/src/components/mobile/BookmarkList.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { ScrollView, Text, TouchableOpacity, View, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+
+import { useBookmarkStore } from '../../store/bookmarkStore';
+
+export default function BookmarkList() {
+  const { bookmarks } = useBookmarkStore();
+  const router = useRouter();
+
+  if (bookmarks.length === 0) {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.emptyIcon}>☆</Text>
+        <Text style={styles.emptyTitle}>No bookmarks yet</Text>
+        <Text style={styles.emptySubtitle}>Items you bookmark will appear here.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView contentContainerStyle={styles.list}>
+      {bookmarks.map((item) => (
+        <TouchableOpacity
+          key={item.itemId}
+          testID={`bookmark-item-${item.itemId}`}
+          style={styles.card}
+          onPress={() => router.push(item.url as any)}
+          activeOpacity={0.75}
+          accessibilityRole="link"
+          accessibilityLabel={item.title}
+        >
+          <Text style={styles.cardTitle}>{item.title}</Text>
+          <Text style={styles.cardType}>{item.itemType}</Text>
+        </TouchableOpacity>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  list: { padding: 16, gap: 10 },
+  card: {
+    backgroundColor: '#f8fafc',
+    borderRadius: 12,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+  },
+  cardTitle: { fontSize: 15, fontWeight: '600', color: '#1e293b' },
+  cardType: { fontSize: 12, color: '#64748b', marginTop: 4, textTransform: 'capitalize' },
+  empty: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 40 },
+  emptyIcon: { fontSize: 48, marginBottom: 12 },
+  emptyTitle: { fontSize: 18, fontWeight: '700', color: '#1e293b', marginBottom: 6 },
+  emptySubtitle: { fontSize: 14, color: '#64748b', textAlign: 'center' },
+});

--- a/src/store/bookmarkStore.ts
+++ b/src/store/bookmarkStore.ts
@@ -1,0 +1,60 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import apiService from '../services/api';
+import logger from '../utils/logger';
+
+export interface BookmarkItem {
+  itemId: string;
+  itemType: string;
+  title: string;
+  url: string;
+}
+
+interface BookmarkState {
+  bookmarks: BookmarkItem[];
+  isLoading: boolean;
+  addBookmark: (item: BookmarkItem) => Promise<void>;
+  removeBookmark: (itemId: string) => Promise<void>;
+  isBookmarked: (itemId: string) => boolean;
+}
+
+export const useBookmarkStore = create<BookmarkState>()(
+  persist(
+    (set, get) => ({
+      bookmarks: [],
+      isLoading: false,
+
+      addBookmark: async (item) => {
+        set((s) => ({ bookmarks: [...s.bookmarks, item] }));
+        try {
+          await apiService.post('/api/bookmarks', { itemId: item.itemId, itemType: item.itemType });
+        } catch (error: any) {
+          if (error.code !== 'ERR_NETWORK' && error.message !== 'Network Error') {
+            logger.error('bookmarkStore: addBookmark sync failed', error);
+          }
+        }
+      },
+
+      removeBookmark: async (itemId) => {
+        set((s) => ({ bookmarks: s.bookmarks.filter((b) => b.itemId !== itemId) }));
+        try {
+          await apiService.delete(`/api/bookmarks/${itemId}`);
+        } catch (error: any) {
+          if (error.code !== 'ERR_NETWORK' && error.message !== 'Network Error') {
+            logger.error('bookmarkStore: removeBookmark sync failed', error);
+          }
+        }
+      },
+
+      isBookmarked: (itemId) => get().bookmarks.some((b) => b.itemId === itemId),
+    }),
+    {
+      name: 'bookmarks',
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({ bookmarks: state.bookmarks }),
+    },
+  ),
+);

--- a/tests/components/Bookmark.test.tsx
+++ b/tests/components/Bookmark.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import BookmarkButton from '../../src/components/mobile/BookmarkButton';
+import BookmarkList from '../../src/components/mobile/BookmarkList';
+import { useBookmarkStore } from '../../src/store/bookmarkStore';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn().mockResolvedValue(null),
+  setItem: jest.fn().mockResolvedValue(undefined),
+  removeItem: jest.fn().mockResolvedValue(undefined),
+  clear: jest.fn().mockResolvedValue(undefined),
+  getAllKeys: jest.fn().mockResolvedValue([]),
+  multiGet: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../../src/services/api', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn().mockResolvedValue({ data: {} }),
+    delete: jest.fn().mockResolvedValue({ data: {} }),
+  },
+}));
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+import apiService from '../../src/services/api';
+
+const mockPost = apiService.post as jest.Mock;
+const mockDelete = apiService.delete as jest.Mock;
+
+const ITEM = { itemId: 'lesson-1', itemType: 'lesson', title: 'Intro to React', url: '/lessons/lesson-1' };
+
+beforeEach(() => {
+  useBookmarkStore.setState({ bookmarks: [], isLoading: false });
+  mockPost.mockClear();
+  mockDelete.mockClear();
+});
+
+// ── BookmarkButton ─────────────────────────────────────────────────────────
+
+describe('BookmarkButton', () => {
+  it('renders in un-bookmarked state', () => {
+    const { getByText } = render(<BookmarkButton item={ITEM} />);
+    expect(getByText('Bookmark')).toBeTruthy();
+  });
+
+  it('pressing adds item to store and calls POST /api/bookmarks', async () => {
+    const { getByTestId } = render(<BookmarkButton item={ITEM} />);
+    fireEvent.press(getByTestId('bookmark-button'));
+
+    await waitFor(() => {
+      expect(useBookmarkStore.getState().isBookmarked(ITEM.itemId)).toBe(true);
+    });
+    expect(mockPost).toHaveBeenCalledWith('/api/bookmarks', {
+      itemId: ITEM.itemId,
+      itemType: ITEM.itemType,
+    });
+  });
+
+  it('pressing again removes item from store and calls DELETE /api/bookmarks/:id', async () => {
+    useBookmarkStore.setState({ bookmarks: [ITEM], isLoading: false });
+
+    const { getByTestId } = render(<BookmarkButton item={ITEM} />);
+    fireEvent.press(getByTestId('bookmark-button'));
+
+    await waitFor(() => {
+      expect(useBookmarkStore.getState().isBookmarked(ITEM.itemId)).toBe(false);
+    });
+    expect(mockDelete).toHaveBeenCalledWith(`/api/bookmarks/${ITEM.itemId}`);
+  });
+
+  it('shows "Bookmarked" label when item is already bookmarked', () => {
+    useBookmarkStore.setState({ bookmarks: [ITEM], isLoading: false });
+    const { getByText } = render(<BookmarkButton item={ITEM} />);
+    expect(getByText('Bookmarked')).toBeTruthy();
+  });
+
+  it('persists bookmark to AsyncStorage via store persist middleware', async () => {
+    const AsyncStorage = require('@react-native-async-storage/async-storage');
+    const { getByTestId } = render(<BookmarkButton item={ITEM} />);
+    fireEvent.press(getByTestId('bookmark-button'));
+
+    await waitFor(() => {
+      expect(useBookmarkStore.getState().bookmarks).toContainEqual(ITEM);
+    });
+    expect(AsyncStorage.setItem).toHaveBeenCalled();
+  });
+});
+
+// ── BookmarkList ───────────────────────────────────────────────────────────
+
+describe('BookmarkList', () => {
+  it('shows empty state when no bookmarks', () => {
+    const { getByText } = render(<BookmarkList />);
+    expect(getByText('No bookmarks yet')).toBeTruthy();
+  });
+
+  it('renders bookmarked items from store', () => {
+    useBookmarkStore.setState({ bookmarks: [ITEM], isLoading: false });
+    const { getByTestId } = render(<BookmarkList />);
+    expect(getByTestId(`bookmark-item-${ITEM.itemId}`)).toBeTruthy();
+  });
+
+  it('renders multiple bookmarks', () => {
+    const items = [
+      ITEM,
+      { itemId: 'course-2', itemType: 'course', title: 'Advanced TypeScript', url: '/courses/course-2' },
+    ];
+    useBookmarkStore.setState({ bookmarks: items, isLoading: false });
+    const { getByTestId } = render(<BookmarkList />);
+    expect(getByTestId('bookmark-item-lesson-1')).toBeTruthy();
+    expect(getByTestId('bookmark-item-course-2')).toBeTruthy();
+  });
+
+  it('does not show empty state when bookmarks exist', () => {
+    useBookmarkStore.setState({ bookmarks: [ITEM], isLoading: false });
+    const { queryByText } = render(<BookmarkList />);
+    expect(queryByText('No bookmarks yet')).toBeNull();
+  });
+});


### PR DESCRIPTION

closes #153 


  Fixes #153 — bookmarks were not persisting saved items.
  
  ## What changed
  
  ### src/store/bookmarkStore.ts (new)
  - Zustand store with `persist` middleware writing to AsyncStorage key `bookmarks`
  - `addBookmark(item)` — adds to store, syncs POST /api/bookmarks to server
  - `removeBookmark(itemId)` — removes from store, syncs DELETE /api/bookmarks/:itemId
  - `isBookmarked(itemId)` — selector
  - Matches existing store patterns (notificationStore, settingsStore)
  
  ### src/components/mobile/BookmarkButton.tsx (updated)
  - Now owns the toggle logic — reads/writes directly to bookmarkStore
  - Accepts `item: BookmarkItem` prop instead of stateless `isBookmarked`/`onToggle`
  - Handles add/remove with server sync on press
  
  ### src/components/mobile/BookmarkList.tsx (new)
  - Reads bookmarks from store
  - Renders saved items with title, type, and navigation link
  - Shows empty state when no bookmarks exist
  
  ### tests/components/Bookmark.test.tsx (new, 9 tests)
  - Pressing BookmarkButton adds item to store + calls POST /api/bookmarks
  - Pressing again removes it + calls DELETE /api/bookmarks/:id
  - AsyncStorage.setItem called on bookmark add (persist middleware)
  - BookmarkList renders items from store
  - BookmarkList shows empty state when no bookmarks
  
  ## Test results
  9/9 new tests pass. Full suite: 247 tests passing, same 2 pre-existing failures unrelated to this PR.
  