### PR TITLE
refactor(navigation): remove unused navigation type imports and dupli…

### DIFF
--- a/src/components/mobile/MobileCourseViewer.tsx
+++ b/src/components/mobile/MobileCourseViewer.tsx
@@ -19,7 +19,6 @@ import BookmarkButton from "./BookmarkButton";
 import LessonCarousel from "./LessonCarousel";
 import MobileSyllabus from "./MobileSyllabus";
 import { useAnalytics } from "../../hooks/useAnalytics";
-import { RootStackParamList } from "../../navigation/types";
 import { Course, Lesson, Note } from "../../types/course";
 import { AnalyticsEvent, ScreenName } from "../../utils/trackingEvents";
 import { ErrorBoundary } from "../common/ErrorBoundary";

--- a/src/components/mobile/MobileQuizManager/index.tsx
+++ b/src/components/mobile/MobileQuizManager/index.tsx
@@ -13,7 +13,6 @@ import QuizCarousel from './QuizCarousel';
 import QuizProgress from './QuizProgress';
 import QuizResults from './QuizResults';
 import { useAnalytics } from '../../../hooks/useAnalytics';
-import { QuizNavigationProp } from '../../../navigation/types';
 import { useQuizStore } from '../../../store/quizStore';
 import { Quiz, Course } from '../../../types/course';
 import logger from '../../../utils/logger';

--- a/src/navigation/linking.ts
+++ b/src/navigation/linking.ts
@@ -5,28 +5,6 @@ import { NotificationData, NotificationType } from '../types/notifications';
 import { RootStackParamList } from './types';
 import logger from '../utils/logger';
 
-// Define your navigation param list types
-export type RootStackParamList = {
-  // Main tabs
-  Home: undefined;
-  Courses: undefined;
-  Messages: undefined;
-  Learning: undefined;
-  Community: undefined;
-  Profile: undefined;
-  Achievements: undefined;
-
-  // Detail screens
-  CourseDetail: { courseId: string };
-  Chat: { conversationId: string };
-  AchievementDetail: { achievementId: string };
-  CommunityPost: { postId: string };
-
-  // Settings
-  Settings: undefined;
-  NotificationSettings: undefined;
-};
-
 const prefix = Linking.createURL('/');
 
 /**


### PR DESCRIPTION
closes #159 

- Remove unused QuizNavigationProp import from MobileQuizManager
- Remove unused RootStackParamList import from MobileCourseViewer
- Remove duplicate RootStackParamList declaration in linking.ts (was re-declaring a type already imported from navigation/types)

## Summary
  
  Follow-up cleanup after the expo-router navigation consolidation (which removed `AppNavigator.tsx` and switched navigation props away
  from `RootStackParamList`-bound types). Several files were left with stale imports and a duplicate type declaration that no longer served
  any purpose.
  
  ## Problem
  
  After the navigation refactor:
  - `MobileQuizManager/index.tsx` still imported `QuizNavigationProp` from `navigation/types`, but the `navigation` prop had already been
  changed to use `LegacyNavigationProp` — making the import dead code
  - `MobileCourseViewer.tsx` still imported `RootStackParamList` from `navigation/types`, but the `navigation` prop had already been
  changed to `NativeStackNavigationProp<Record<string, object | undefined>>` — making the import dead code
  - `src/navigation/linking.ts` was importing `RootStackParamList` from `./types` and then immediately re-declaring its own
  `RootStackParamList` with a different, incomplete shape — a type conflict hiding in plain sight
  
  ## Changes
  
  - Removed unused `QuizNavigationProp` import from `MobileQuizManager/index.tsx`
  - Removed unused `RootStackParamList` import from `MobileCourseViewer.tsx`
  - Removed the duplicate `RootStackParamList` declaration in `linking.ts`, leaving only the import from `navigation/types` as the single
  source of truth
  
  ## What was tested
  
  - No functional changes — import-only cleanup
  - Existing test suite passes (153 tests)
  - No circular dependencies introduced