### PR TITLE
feat: add release workflow (Close #124)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,211 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: 'Deploy to stores (yes|no)'
+        required: true
+        default: 'no'
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  version-bump:
+    name: Version Bump & Changelog
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.version.outputs.new_version }}
+      version_changed: ${{ steps.version.outputs.version_changed }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version and generate changelog
+        id: version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get current version
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          echo "Current version: $CURRENT_VERSION"
+
+          # Get commits since last tag
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            COMMITS=$(git log --pretty=format:"%s" --no-merges)
+          else
+            COMMITS=$(git log ${LAST_TAG}..HEAD --pretty=format:"%s" --no-merges)
+          fi
+
+          echo "Commits since last tag:"
+          echo "$COMMITS"
+
+          # Determine version bump type
+          if echo "$COMMITS" | grep -qE "^(feat|feature)(\(.*\))?!:"; then
+            BUMP="minor"
+          elif echo "$COMMITS" | grep -qE "^(fix|bug)(\(.*\))?!:"; then
+            BUMP="patch"
+          elif echo "$COMMITS" | grep -qE "BREAKING CHANGE"; then
+            BUMP="major"
+          elif echo "$COMMITS" | grep -qE "^(feat|feature)(\(.*\))?:."; then
+            BUMP="minor"
+          elif echo "$COMMITS" | grep -qE "^(fix|bug)(\(.*\))?:."; then
+            BUMP="patch"
+          else
+            echo "No version-worthy changes detected"
+            echo "version_changed=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Bump type: $BUMP"
+
+          # Bump version
+          NEW_VERSION=$(npm version $BUMP --no-git-tag-version)
+          NEW_VERSION=${NEW_VERSION#v}
+          echo "New version: $NEW_VERSION"
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "version_changed=true" >> $GITHUB_OUTPUT
+
+          # Generate changelog
+          npm install -g conventional-changelog-cli
+          conventional-changelog -p angular -i CHANGELOG.md -s -r 0 || conventional-changelog -p angular -i CHANGELOG.md -s
+
+          # Commit and push
+          git add package.json CHANGELOG.md
+          git commit -m "chore(release): v$NEW_VERSION [skip ci]" || echo "No changes to commit"
+          git push origin main
+
+  create-github-release:
+    name: Create GitHub Release
+    needs: version-bump
+    if: needs.version-bump.outputs.version_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version
+        id: get_version
+        run: |
+          VERSION=${{ needs.version-bump.outputs.new_version }}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Generate release notes
+        id: release_notes
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            NOTES=$(git log --pretty=format:"* %s" --no-merges)
+          else
+            NOTES=$(git log ${LAST_TAG}..HEAD --pretty=format:"* %s" --no-merges)
+          fi
+          echo "NOTES<<EOF" >> $GITHUB_OUTPUT
+          echo "$NOTES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.get_version.outputs.version }}
+          name: Release v${{ steps.get_version.outputs.version }}
+          body: |
+            ## What's Changed
+
+            ${{ steps.release_notes.outputs.NOTES }}
+
+            **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ github.event.before }}...v${{ steps.get_version.outputs.version }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  eas-build:
+    name: EAS Build (Production)
+    needs: [version-bump, create-github-release]
+    if: always() && needs.version-bump.outputs.version_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          expo-version: latest
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build on EAS (Android & iOS)
+        run: eas build --platform all --profile production --non-interactive --no-wait
+
+  submit-to-stores:
+    name: Submit to App Stores
+    needs: eas-build
+    if: ${{ github.event.inputs.deploy == 'yes' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          expo-version: latest
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Submit to Google Play
+        run: eas submit --platform android --profile production --non-interactive
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Submit to App Store
+        run: eas submit --platform ios --profile production --non-interactive
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds automated release workflow with version bumping on merge to main
- Implements auto-changelog generation using conventional commits
- Adds EAS build and submit workflow for Android & iOS
- Creates GitHub release notes automatically

## Changes
- Creates `.github/workflows/release.yml` with:
  - Version bump based on conventional commit messages
  - Automatic CHANGELOG.md generation
  - EAS build trigger for production builds
  - Optional store submission (workflow_dispatch with deploy=yes)
  - GitHub release creation with auto-generated notes

Close #124