### PR TITLE
refactor: consolidate axios instance and remove duplicated client usage

### DIFF
--- a/src/services/api/axios.config.ts
+++ b/src/services/api/axios.config.ts
@@ -43,6 +43,11 @@ function processRefreshQueue(token: string | null, error: unknown) {
 
 apiClient.interceptors.request.use(
   async (config: InternalAxiosRequestConfig) => {
+    // Skip adding token for refresh requests
+    if (config.url?.includes("/auth/refresh")) {
+      return config;
+    }
+
     const token = await getAccessToken();
 
     if (token) {
@@ -83,7 +88,7 @@ apiClient.interceptors.response.use(
 
     // ─── 401: Token refresh flow ───────────────────────────────────────────
 
-    if (status === 401 && !originalRequest._retry) {
+    if (status === 401 && !originalRequest._retry && !originalRequest.url?.includes("/auth/refresh")) {
       originalRequest._retry = true;
 
       if (isRefreshing) {
@@ -104,7 +109,7 @@ apiClient.interceptors.response.use(
         const refreshToken = await getRefreshToken();
         if (!refreshToken) throw new Error("No refresh token");
 
-        const { data } = await axios.post(`${baseURL}/auth/refresh`, {
+        const { data } = await apiClient.post("/auth/refresh", {
           refreshToken,
         });
 

--- a/src/services/pushNotifications.ts
+++ b/src/services/pushNotifications.ts
@@ -4,6 +4,7 @@ import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
 import { NotificationData, NotificationType } from '../types/notifications';
 import logger from '../utils/logger';
+import apiClient from './api/axios.config';
 
 // Configure how notifications are handled when app is in foreground
 Notifications.setNotificationHandler({
@@ -144,7 +145,7 @@ export function getChannelId(type: NotificationType): string {
 export async function registerTokenWithBackend(token: string): Promise<boolean> {
   try {
     // TODO: Replace with actual API endpoint
-    // const response = await axios.post('/api/notifications/register', {
+    // const response = await apiClient.post('/api/notifications/register', {
     //   token,
     //   platform: Platform.OS,
     //   deviceId: Device.deviceName,
@@ -166,7 +167,7 @@ export async function registerTokenWithBackend(token: string): Promise<boolean> 
 export async function unregisterTokenFromBackend(token: string): Promise<boolean> {
   try {
     // TODO: Replace with actual API endpoint
-    // const response = await axios.delete('/api/notifications/unregister', {
+    // const response = await apiClient.delete('/api/notifications/unregister', {
     //   data: { token },
     // });
     // return response.data.success;


### PR DESCRIPTION
### Pull Request Description
```markdown
## Overview
This PR resolves issue #161 by consolidating the API client configuration to ensure that a single, unified `apiClient` instance is used consistently throughout the application. 

Previously, the application suffered from duplicated client creation and direct imports of `axios` in service logic (specifically during the token refresh flow), which caused inconsistencies in request configurations, timeout handling, and interceptor behaviors.

## Specifications Addressed
- Use a single axios instance (`apiClient`) everywhere
- Remove duplicate client creation
- Replace direct `axios` imports with `apiClient`

## Key Changes
- **`src/services/api/axios.config.ts`**:
    - Replaced the direct `axios.post` call for the token refresh flow with `apiClient.post`.
    - Enhanced the **request interceptor** to explicitly skip appending the `Authorization` header for `/auth/refresh` requests.
    - Updated the **response interceptor** to bypass the 401 retry logic for refresh requests, eliminating the potential for infinite retry loops if the refresh token expires.
- **`src/services/pushNotifications.ts`**:
    - Refactored commented-out direct `axios` usages to use `apiClient` instead, guaranteeing future API interactions adhere to the centralized configuration.

## Impact
- **Maintainability:** Establishes a single source of truth for base URLs, timeouts, and headers.
- **Consistency:** Ensures all network requests share the same logging and error-handling policies.
- **Stability:** Hardens the token refresh flow to prevent recursive retries and network hangs.

## Related Issues
Fixes #161
```