### PR TITLE
docs: add DEPLOY.md and deployment section to README (#126)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,3 +230,49 @@ These profiles can also be used when submitting:
 - `eas submit --profile production` will use the production credentials defined in the `submit.production` section of `eas.json`.
 
 Refer to the official EAS docs for more details.
+
+
+---
+
+## 🚀 Deployment
+
+TeachLink Mobile uses **Expo Application Services (EAS)** for building and submitting to the app stores.
+
+> 📖 For the full deployment guide, see **[DEPLOY.md](./DEPLOY.md)**
+
+### Quick Start
+
+```bash
+# Install EAS CLI
+npm install -g eas-cli
+
+# Authenticate
+eas login
+
+# Deploy to Android
+npm run deploy:android
+
+# Deploy to iOS
+npm run deploy:ios
+
+# Deploy to both stores
+npm run deploy:both
+
+# Create a preview build for testing
+npm run deploy:preview
+```
+
+### Environment Setup
+
+Create a `.env` file in the project root:
+
+```env
+EXPO_PUBLIC_API_BASE_URL=https://api.teachlink.com
+EXPO_PUBLIC_SOCKET_URL=wss://api.teachlink.com
+EXPO_PUBLIC_APP_ENV=production
+EXPO_PUBLIC_ENABLE_PUSH_NOTIFICATIONS=true
+```
+
+> ⚠️ Never commit your `.env` file. It is listed in `.gitignore`.
+
+See [DEPLOY.md](./DEPLOY.md) for platform-specific setup (Google Play & App Store), build profiles, troubleshooting, and security notes.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,8 @@
 
 This directory contains deployment scripts for the TeachLink mobile app using Expo Application Services (EAS).
 
+> For the full deployment guide, see [DEPLOY.md](./DEPLOY.md)  
+
 ## Available Scripts
 
 ### 📱 Platform-Specific Deployments
@@ -118,3 +120,48 @@ EXPO_PUBLIC_ENVIRONMENT=production
 - Use environment variables for API keys and secrets
 - Regularly rotate your service account keys
 - Review app permissions before submission
+
+---
+
+## Deployment
+
+TeachLink Mobile uses **Expo Application Services (EAS)** for building and submitting to the app stores.
+
+> For the full deployment guide, see **[DEPLOY.md](./DEPLOY.md)**
+
+### Quick Start
+
+```bash
+# Install EAS CLI
+npm install -g eas-cli
+
+# Authenticate
+eas login
+
+# Deploy to Android
+npm run deploy:android
+
+# Deploy to iOS
+npm run deploy:ios
+
+# Deploy to both stores
+npm run deploy:both
+
+# Create a preview build for testing
+npm run deploy:preview
+```
+
+### Environment Setup
+
+Create a `.env` file in the project root:
+
+```env
+EXPO_PUBLIC_API_BASE_URL=https://api.teachlink.com
+EXPO_PUBLIC_SOCKET_URL=wss://api.teachlink.com
+EXPO_PUBLIC_APP_ENV=production
+EXPO_PUBLIC_ENABLE_PUSH_NOTIFICATIONS=true
+```
+
+> Never commit your `.env` file. It is listed in `.gitignore`.
+
+See [DEPLOY.md](./DEPLOY.md) for platform-specific setup (Google Play & App Store), build profiles, troubleshooting, and security notes.


### PR DESCRIPTION
## 📄 Summary

Closes #126 

This PR adds full deployment documentation for the TeachLink Mobile app, addressing the gap where `deploy-android.sh`, `deploy-ios.sh`, and related scripts existed with no usage documentation.

## Changes

- **`DEPLOY.md`** *(created)* — Full deployment guide covering:
  - Prerequisites (Node.js, EAS CLI, Expo account)
  - Environment variable setup based on `.env.example`
  - Android deployment (Google Play setup + script usage)
  - iOS deployment (Apple Developer setup + script usage)
  - Cross-platform and preview build commands
  - Build profiles (`development`, `preview`, `production`)
  - Security notes and troubleshooting guide

- **`README.md`** *(updated)* — Added a `## 🚀 Deployment` section with:
  - Quick-start commands for all deploy scripts
  - Environment variable setup summary
  - Link to full `DEPLOY.md`

## Checklist

- [x] `DEPLOY.md` created
- [x] `README.md` updated with deployment section
- [x] Environment variables match `.env.example` exactly
- [x] Scripts documented accurately based on `deploy-android.sh` and `deploy-ios.sh`
- [x] Security and troubleshooting notes included
- [x] No console errors / no code changes — documentation only