### PR TITLE
feat: implement app content cache versioning with smart updates

### DIFF
--- a/src/__tests__/utils/cacheVersioning.test.ts
+++ b/src/__tests__/utils/cacheVersioning.test.ts
@@ -1,0 +1,207 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {
+  parseSemver,
+  shouldInvalidateCache,
+  getStoredCacheVersion,
+  setStoredCacheVersion,
+  handleCacheVersionUpdate,
+} from '../../utils/cacheVersioning';
+import { ImageCache } from '../../utils/imageCache';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  getAllKeys: jest.fn(),
+  multiRemove: jest.fn(),
+}));
+
+jest.mock('../../utils/imageCache', () => ({
+  ImageCache: {
+    clearCache: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const mockStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+const mockImageCache = ImageCache as jest.Mocked<typeof ImageCache>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockStorage.getItem.mockResolvedValue(null);
+  mockStorage.setItem.mockResolvedValue(undefined);
+  mockStorage.getAllKeys.mockResolvedValue([]);
+  mockStorage.multiRemove.mockResolvedValue(undefined);
+  mockImageCache.clearCache.mockResolvedValue(undefined);
+});
+
+// ─── parseSemver ──────────────────────────────────────────────────────────────
+
+describe('parseSemver', () => {
+  it('parses a valid semver string', () => {
+    expect(parseSemver('1.2.3')).toEqual({ major: 1, minor: 2, patch: 3 });
+  });
+
+  it('parses 0.0.0', () => {
+    expect(parseSemver('0.0.0')).toEqual({ major: 0, minor: 0, patch: 0 });
+  });
+
+  it('returns null for invalid strings', () => {
+    expect(parseSemver('1.2')).toBeNull();
+    expect(parseSemver('1.2.3.4')).toBeNull();
+    expect(parseSemver('abc')).toBeNull();
+    expect(parseSemver('')).toBeNull();
+  });
+});
+
+// ─── shouldInvalidateCache ────────────────────────────────────────────────────
+
+describe('shouldInvalidateCache', () => {
+  it('preserves cache on patch bump', () => {
+    expect(shouldInvalidateCache('1.0.0', '1.0.1')).toBe(false);
+    expect(shouldInvalidateCache('2.3.4', '2.3.9')).toBe(false);
+  });
+
+  it('preserves cache when version is identical', () => {
+    expect(shouldInvalidateCache('1.2.3', '1.2.3')).toBe(false);
+  });
+
+  it('invalidates cache on minor bump', () => {
+    expect(shouldInvalidateCache('1.0.0', '1.1.0')).toBe(true);
+    expect(shouldInvalidateCache('1.2.3', '1.3.0')).toBe(true);
+  });
+
+  it('invalidates cache on major bump', () => {
+    expect(shouldInvalidateCache('1.0.0', '2.0.0')).toBe(true);
+    expect(shouldInvalidateCache('1.9.9', '2.0.0')).toBe(true);
+  });
+
+  it('invalidates cache when either version is unparseable', () => {
+    expect(shouldInvalidateCache('bad', '1.0.0')).toBe(true);
+    expect(shouldInvalidateCache('1.0.0', 'bad')).toBe(true);
+    expect(shouldInvalidateCache('bad', 'bad')).toBe(true);
+  });
+});
+
+// ─── getStoredCacheVersion ────────────────────────────────────────────────────
+
+describe('getStoredCacheVersion', () => {
+  it('returns the stored version string', async () => {
+    mockStorage.getItem.mockResolvedValue('1.2.3');
+    await expect(getStoredCacheVersion()).resolves.toBe('1.2.3');
+  });
+
+  it('returns null when nothing is stored', async () => {
+    mockStorage.getItem.mockResolvedValue(null);
+    await expect(getStoredCacheVersion()).resolves.toBeNull();
+  });
+
+  it('returns null and logs on storage error', async () => {
+    mockStorage.getItem.mockRejectedValue(new Error('storage error'));
+    await expect(getStoredCacheVersion()).resolves.toBeNull();
+  });
+});
+
+// ─── setStoredCacheVersion ────────────────────────────────────────────────────
+
+describe('setStoredCacheVersion', () => {
+  it('writes the version to AsyncStorage', async () => {
+    await setStoredCacheVersion('2.0.0');
+    expect(mockStorage.setItem).toHaveBeenCalledWith('@teachlink_cache_version', '2.0.0');
+  });
+
+  it('does not throw on storage error', async () => {
+    mockStorage.setItem.mockRejectedValue(new Error('write error'));
+    await expect(setStoredCacheVersion('1.0.0')).resolves.toBeUndefined();
+  });
+});
+
+// ─── handleCacheVersionUpdate ─────────────────────────────────────────────────
+
+describe('handleCacheVersionUpdate', () => {
+  it('invalidates cache and returns true when no version is stored', async () => {
+    mockStorage.getItem.mockResolvedValue(null);
+    mockStorage.getAllKeys.mockResolvedValue(['@teachlink_courses', '@teachlink_user']);
+
+    const result = await handleCacheVersionUpdate('1.0.0');
+
+    expect(result).toBe(true);
+    expect(mockStorage.multiRemove).toHaveBeenCalledWith(['@teachlink_courses', '@teachlink_user']);
+    expect(mockImageCache.clearCache).toHaveBeenCalled();
+    expect(mockStorage.setItem).toHaveBeenCalledWith('@teachlink_cache_version', '1.0.0');
+  });
+
+  it('invalidates cache on major version bump', async () => {
+    mockStorage.getItem.mockResolvedValue('1.0.0');
+    mockStorage.getAllKeys.mockResolvedValue(['@teachlink_cache_version', '@teachlink_courses']);
+
+    const result = await handleCacheVersionUpdate('2.0.0');
+
+    expect(result).toBe(true);
+    // Should NOT remove the version key itself
+    expect(mockStorage.multiRemove).toHaveBeenCalledWith(['@teachlink_courses']);
+    expect(mockImageCache.clearCache).toHaveBeenCalled();
+  });
+
+  it('invalidates cache on minor version bump', async () => {
+    mockStorage.getItem.mockResolvedValue('1.0.0');
+    mockStorage.getAllKeys.mockResolvedValue(['@teachlink_cache_version', '@teachlink_courses']);
+
+    const result = await handleCacheVersionUpdate('1.1.0');
+
+    expect(result).toBe(true);
+    expect(mockImageCache.clearCache).toHaveBeenCalled();
+  });
+
+  it('preserves cache on patch version bump', async () => {
+    mockStorage.getItem.mockResolvedValue('1.0.0');
+
+    const result = await handleCacheVersionUpdate('1.0.1');
+
+    expect(result).toBe(false);
+    expect(mockStorage.multiRemove).not.toHaveBeenCalled();
+    expect(mockImageCache.clearCache).not.toHaveBeenCalled();
+    expect(mockStorage.setItem).toHaveBeenCalledWith('@teachlink_cache_version', '1.0.1');
+  });
+
+  it('preserves cache when version is unchanged', async () => {
+    mockStorage.getItem.mockResolvedValue('1.2.3');
+
+    const result = await handleCacheVersionUpdate('1.2.3');
+
+    expect(result).toBe(false);
+    expect(mockStorage.multiRemove).not.toHaveBeenCalled();
+    expect(mockImageCache.clearCache).not.toHaveBeenCalled();
+  });
+
+  it('skips multiRemove when there are no keys to remove', async () => {
+    mockStorage.getItem.mockResolvedValue(null);
+    mockStorage.getAllKeys.mockResolvedValue(['@teachlink_cache_version']);
+
+    await handleCacheVersionUpdate('1.0.0');
+
+    expect(mockStorage.multiRemove).not.toHaveBeenCalled();
+    expect(mockImageCache.clearCache).toHaveBeenCalled();
+  });
+
+  it('still updates the version even if cache clearing throws', async () => {
+    mockStorage.getItem.mockResolvedValue('1.0.0');
+    mockStorage.getAllKeys.mockRejectedValue(new Error('storage error'));
+
+    const result = await handleCacheVersionUpdate('2.0.0');
+
+    expect(result).toBe(true);
+    expect(mockStorage.setItem).toHaveBeenCalledWith('@teachlink_cache_version', '2.0.0');
+  });
+});

--- a/src/utils/cacheVersioning.ts
+++ b/src/utils/cacheVersioning.ts
@@ -1,0 +1,101 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { ImageCache } from './imageCache';
+import logger from './logger'; // eslint-disable-line import/no-named-as-default
+
+/**
+ * Parses a semver string into its numeric components.
+ * Returns null if the string is not a valid semver.
+ */
+export function parseSemver(
+  version: string
+): { major: number; minor: number; patch: number } | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match) return null;
+  return {
+    major: parseInt(match[1], 10),
+    minor: parseInt(match[2], 10),
+    patch: parseInt(match[3], 10),
+  };
+}
+
+/**
+ * Determines whether a cache should be invalidated based on version change.
+ *
+ * Rules:
+ * - Major version bump  → invalidate (breaking change)
+ * - Minor version bump  → invalidate (new features may change data shape)
+ * - Patch version bump  → preserve  (backwards-compatible fix)
+ * - Same version        → preserve
+ */
+export function shouldInvalidateCache(cachedVersion: string, newVersion: string): boolean {
+  const cached = parseSemver(cachedVersion);
+  const next = parseSemver(newVersion);
+
+  if (!cached || !next) {
+    // Unparseable version — invalidate to be safe
+    return true;
+  }
+
+  if (next.major !== cached.major) return true;
+  if (next.minor !== cached.minor) return true;
+  return false;
+}
+
+const CACHE_VERSION_KEY = '@teachlink_cache_version';
+
+/**
+ * Returns the currently stored cache version, or null if none exists.
+ */
+export async function getStoredCacheVersion(): Promise<string | null> {
+  try {
+    return await AsyncStorage.getItem(CACHE_VERSION_KEY);
+  } catch (error) {
+    logger.error('Failed to read cache version', error);
+    return null;
+  }
+}
+
+/**
+ * Persists the given version string as the current cache version.
+ */
+export async function setStoredCacheVersion(version: string): Promise<void> {
+  try {
+    await AsyncStorage.setItem(CACHE_VERSION_KEY, version);
+  } catch (error) {
+    logger.error('Failed to write cache version', error);
+  }
+}
+
+/**
+ * Checks the stored cache version against `newVersion` and, when a
+ * major or minor bump is detected, clears all AsyncStorage entries
+ * (except the version key itself) and the image cache.
+ *
+ * @returns `true` if the cache was invalidated, `false` if it was preserved.
+ */
+export async function handleCacheVersionUpdate(newVersion: string): Promise<boolean> {
+  const storedVersion = await getStoredCacheVersion();
+
+  const needsInvalidation =
+    storedVersion === null || shouldInvalidateCache(storedVersion, newVersion);
+
+  if (needsInvalidation) {
+    logger.info(`Cache invalidated: ${storedVersion ?? 'none'} → ${newVersion}`);
+    try {
+      const allKeys = await AsyncStorage.getAllKeys();
+      const keysToRemove = allKeys.filter(k => k !== CACHE_VERSION_KEY);
+      if (keysToRemove.length > 0) {
+        await AsyncStorage.multiRemove(keysToRemove);
+      }
+      await ImageCache.clearCache();
+    } catch (error) {
+      logger.error('Error clearing cache during version update', error);
+    }
+  } else {
+    logger.info(`Cache preserved: ${storedVersion} → ${newVersion} (patch update)`);
+  }
+
+  await setStoredCacheVersion(newVersion);
+  return needsInvalidation;
+}


### PR DESCRIPTION
## Summary

Closes #402

Implements version-aware cache management so patch updates preserve cached content while major/minor updates invalidate it.

## Changes

- **`src/utils/cacheVersioning.ts`** — new utility with:
  - `parseSemver` — parses a semver string into `{major, minor, patch}`
  - `shouldInvalidateCache(cached, new)` — returns `true` on major/minor bump, `false` on patch/same
  - `getStoredCacheVersion` / `setStoredCacheVersion` — AsyncStorage persistence
  - `handleCacheVersionUpdate(newVersion)` — clears AsyncStorage + image cache on breaking change, updates stored version

- **`src/__tests__/utils/cacheVersioning.test.ts`** — 20 tests covering all scenarios

## Behaviour

| Change | Cache |
|--------|-------|
| `1.0.0` → `1.0.1` (patch) | ✅ Preserved |
| `1.0.0` → `1.1.0` (minor) | 🗑 Invalidated |
| `1.0.0` → `2.0.0` (major) | 🗑 Invalidated |
| No stored version | 🗑 Invalidated |

## Testing

All 20 tests pass. Lint and format clean on new files.