### PR TITLE
Binary protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,3 +286,18 @@ EXPO_PUBLIC_ENABLE_PUSH_NOTIFICATIONS=true
 > ⚠️ Never commit your `.env` file. It is listed in `.gitignore`.
 
 See [DEPLOY.md](./DEPLOY.md) for platform-specific setup (Google Play & App Store), build profiles, troubleshooting, and security notes.
+## WebSocket Binary Protocol
+
+Real-time socket payloads now use a protobuf-style binary envelope for `notification_created`, `course_updated`, and `message_received` events.
+
+- Outbound messages are serialized through `encodeBinaryMessage` in `src/services/socket/binaryProtocol.ts`.
+- Inbound binary messages are deserialized through `decodeBinaryMessage` with JSON fallback for unknown event types.
+- Payload reduction can be measured with `estimatePayloadReduction(event, payload)` for regression and bandwidth reporting.
+
+Protocol shape:
+- `field 1` (varint): protocol version
+- `field 2` (varint): event type id for known events
+- known event payload fields start at `field 10`
+- unknown events fallback:
+  - `field 3` (string): event name
+  - `field 4` (string): JSON payload

--- a/src/__tests__/services/binaryProtocol.test.ts
+++ b/src/__tests__/services/binaryProtocol.test.ts
@@ -1,0 +1,45 @@
+import { decodeBinaryMessage, encodeBinaryMessage, estimatePayloadReduction } from "../../services/socket/binaryProtocol";
+
+describe("binaryProtocol", () => {
+  it("encodes and decodes typed notification payload", () => {
+    const payload = {
+      id: "n-1",
+      title: "Reminder",
+      body: "Lesson starts in 10 min",
+      createdAt: "2026-05-27T10:10:10Z",
+      isRead: false,
+    };
+
+    const encoded = encodeBinaryMessage("notification_created", payload);
+    const decoded = decodeBinaryMessage(encoded);
+
+    expect(decoded.event).toBe("notification_created");
+    expect(decoded.payload).toEqual(payload);
+  });
+
+  it("falls back for unknown event payloads", () => {
+    const payload = { ping: "pong", attempt: 2 };
+    const encoded = encodeBinaryMessage("custom_event", payload);
+    const decoded = decodeBinaryMessage(encoded);
+
+    expect(decoded.event).toBe("custom_event");
+    expect(decoded.payload).toEqual(payload);
+  });
+
+  it("reports payload reduction compared to JSON envelope", () => {
+    const payload = {
+      id: "m-1",
+      chatId: "chat-99",
+      senderId: "user-12",
+      content: "Welcome to the class!",
+      timestamp: "2026-05-27T10:10:10Z",
+      isEdited: false,
+    };
+
+    const metrics = estimatePayloadReduction("message_received", payload);
+
+    expect(metrics.jsonBytes).toBeGreaterThan(0);
+    expect(metrics.binaryBytes).toBeGreaterThan(0);
+    expect(metrics.reductionPercent).toBeGreaterThan(0);
+  });
+});

--- a/src/services/socket/binaryProtocol.ts
+++ b/src/services/socket/binaryProtocol.ts
@@ -1,0 +1,203 @@
+const PROTOCOL_VERSION = 1;
+
+export type BinaryValue = string | number | boolean | null | undefined;
+
+type FieldType = "string" | "double" | "bool";
+
+type EventSchema = {
+  typeId: number;
+  fields: Array<{ key: string; type: FieldType }>;
+};
+
+const EVENT_SCHEMAS: Record<string, EventSchema> = {
+  notification_created: {
+    typeId: 1,
+    fields: [
+      { key: "id", type: "string" },
+      { key: "title", type: "string" },
+      { key: "body", type: "string" },
+      { key: "createdAt", type: "string" },
+      { key: "isRead", type: "bool" },
+    ],
+  },
+  course_updated: {
+    typeId: 2,
+    fields: [
+      { key: "id", type: "string" },
+      { key: "title", type: "string" },
+      { key: "progress", type: "double" },
+      { key: "updatedAt", type: "string" },
+    ],
+  },
+  message_received: {
+    typeId: 3,
+    fields: [
+      { key: "id", type: "string" },
+      { key: "chatId", type: "string" },
+      { key: "senderId", type: "string" },
+      { key: "content", type: "string" },
+      { key: "timestamp", type: "string" },
+      { key: "isEdited", type: "bool" },
+    ],
+  },
+};
+
+const TYPE_ID_TO_EVENT: Record<number, string> = Object.fromEntries(
+  Object.entries(EVENT_SCHEMAS).map(([event, schema]) => [schema.typeId, event]),
+);
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const wireType = {
+  varint: 0,
+  fixed64: 1,
+  lengthDelimited: 2,
+} as const;
+
+function encodeVarint(value: number): number[] {
+  const bytes: number[] = [];
+  let current = value >>> 0;
+  while (current > 127) {
+    bytes.push((current & 0x7f) | 0x80);
+    current >>>= 7;
+  }
+  bytes.push(current);
+  return bytes;
+}
+
+function decodeVarint(buffer: Uint8Array, offset: number): [number, number] {
+  let result = 0;
+  let shift = 0;
+  let index = offset;
+  while (index < buffer.length) {
+    const byte = buffer[index++];
+    result |= (byte & 0x7f) << shift;
+    if ((byte & 0x80) === 0) {
+      return [result, index];
+    }
+    shift += 7;
+  }
+  throw new Error("Invalid varint encoding");
+}
+
+function encodeTag(fieldNumber: number, wt: number): number[] {
+  return encodeVarint((fieldNumber << 3) | wt);
+}
+
+function encodeString(fieldNumber: number, value: string): number[] {
+  const payload = Array.from(encoder.encode(value));
+  return [...encodeTag(fieldNumber, wireType.lengthDelimited), ...encodeVarint(payload.length), ...payload];
+}
+
+function encodeBool(fieldNumber: number, value: boolean): number[] {
+  return [...encodeTag(fieldNumber, wireType.varint), ...(value ? [1] : [0])];
+}
+
+function encodeDouble(fieldNumber: number, value: number): number[] {
+  const bytes = new Uint8Array(8);
+  new DataView(bytes.buffer).setFloat64(0, value, true);
+  return [...encodeTag(fieldNumber, wireType.fixed64), ...Array.from(bytes)];
+}
+
+export function encodeBinaryMessage(event: string, payload: Record<string, BinaryValue>): Uint8Array {
+  const schema = EVENT_SCHEMAS[event];
+  const binary: number[] = [];
+
+  binary.push(...encodeTag(1, wireType.varint), ...encodeVarint(PROTOCOL_VERSION));
+
+  if (schema) {
+    binary.push(...encodeTag(2, wireType.varint), ...encodeVarint(schema.typeId));
+    schema.fields.forEach((field, idx) => {
+      const fieldNumber = idx + 10;
+      const value = payload[field.key];
+      if (value === null || value === undefined) return;
+      if (field.type === "string" && typeof value === "string") {
+        binary.push(...encodeString(fieldNumber, value));
+      }
+      if (field.type === "bool" && typeof value === "boolean") {
+        binary.push(...encodeBool(fieldNumber, value));
+      }
+      if (field.type === "double" && typeof value === "number") {
+        binary.push(...encodeDouble(fieldNumber, value));
+      }
+    });
+  } else {
+    binary.push(...encodeString(3, event));
+    binary.push(...encodeString(4, JSON.stringify(payload)));
+  }
+
+  return Uint8Array.from(binary);
+}
+
+export function decodeBinaryMessage(raw: ArrayBuffer | Uint8Array): { event: string; payload: Record<string, BinaryValue> } {
+  const bytes = raw instanceof Uint8Array ? raw : new Uint8Array(raw);
+  let offset = 0;
+  let eventTypeId: number | null = null;
+  let event = "";
+  let jsonPayload = "";
+  const payload: Record<string, BinaryValue> = {};
+
+  while (offset < bytes.length) {
+    const [tag, next] = decodeVarint(bytes, offset);
+    offset = next;
+    const fieldNumber = tag >> 3;
+    const wt = tag & 0x7;
+
+    if (fieldNumber === 1 || fieldNumber === 2) {
+      const [v, n] = decodeVarint(bytes, offset);
+      offset = n;
+      if (fieldNumber === 2) eventTypeId = v;
+      continue;
+    }
+
+    if (fieldNumber === 3 || fieldNumber === 4 || wt === wireType.lengthDelimited) {
+      const [len, n] = decodeVarint(bytes, offset);
+      offset = n;
+      const chunk = bytes.slice(offset, offset + len);
+      offset += len;
+      if (fieldNumber === 3) event = decoder.decode(chunk);
+      else if (fieldNumber === 4) jsonPayload = decoder.decode(chunk);
+      else if (eventTypeId && TYPE_ID_TO_EVENT[eventTypeId]) {
+        const schema = EVENT_SCHEMAS[TYPE_ID_TO_EVENT[eventTypeId]];
+        const field = schema.fields[fieldNumber - 10];
+        if (field?.type === "string") payload[field.key] = decoder.decode(chunk);
+      }
+      continue;
+    }
+
+    if (wt === wireType.varint) {
+      const [v, n] = decodeVarint(bytes, offset);
+      offset = n;
+      if (eventTypeId && TYPE_ID_TO_EVENT[eventTypeId]) {
+        const schema = EVENT_SCHEMAS[TYPE_ID_TO_EVENT[eventTypeId]];
+        const field = schema.fields[fieldNumber - 10];
+        if (field?.type === "bool") payload[field.key] = v === 1;
+      }
+      continue;
+    }
+
+    if (wt === wireType.fixed64) {
+      const slice = bytes.slice(offset, offset + 8);
+      offset += 8;
+      if (eventTypeId && TYPE_ID_TO_EVENT[eventTypeId]) {
+        const schema = EVENT_SCHEMAS[TYPE_ID_TO_EVENT[eventTypeId]];
+        const field = schema.fields[fieldNumber - 10];
+        if (field?.type === "double") payload[field.key] = new DataView(slice.buffer, slice.byteOffset, 8).getFloat64(0, true);
+      }
+    }
+  }
+
+  if (eventTypeId && TYPE_ID_TO_EVENT[eventTypeId]) {
+    return { event: TYPE_ID_TO_EVENT[eventTypeId], payload };
+  }
+
+  return { event, payload: jsonPayload ? (JSON.parse(jsonPayload) as Record<string, BinaryValue>) : payload };
+}
+
+export function estimatePayloadReduction(event: string, payload: Record<string, BinaryValue>): { jsonBytes: number; binaryBytes: number; reductionPercent: number } {
+  const jsonBytes = encoder.encode(JSON.stringify({ event, payload })).length;
+  const binaryBytes = encodeBinaryMessage(event, payload).length;
+  const reductionPercent = Number((((jsonBytes - binaryBytes) / jsonBytes) * 100).toFixed(2));
+  return { jsonBytes, binaryBytes, reductionPercent };
+}

--- a/src/services/socket/index.ts
+++ b/src/services/socket/index.ts
@@ -1,6 +1,7 @@
 import { io, Socket } from "socket.io-client";
 import logger from "../../utils/logger";
 import { getEnv } from "../../config";
+import { decodeBinaryMessage, encodeBinaryMessage } from "./binaryProtocol";
 
 // ─── Reconnection config ──────────────────────────────────────────────────────
 
@@ -70,19 +71,22 @@ class SocketService {
       // ── Real-time event handlers ──────────────────────────────────────
 
       this.socket.on("notification_created", (notification: any) => {
-        logger.info("New notification received:", notification);
+        const parsed = notification instanceof ArrayBuffer || notification instanceof Uint8Array ? decodeBinaryMessage(notification).payload : notification;
+        logger.info("New notification received:", parsed);
         // TODO: Handle notification display/storage
         // This could trigger a notification banner, update notification count, etc.
       });
 
       this.socket.on("course_updated", (courseData: any) => {
-        logger.info("Course updated:", courseData);
+        const parsed = courseData instanceof ArrayBuffer || courseData instanceof Uint8Array ? decodeBinaryMessage(courseData).payload : courseData;
+        logger.info("Course updated:", parsed);
         // TODO: Handle course data refresh
         // This could update cached course data, refresh UI components, etc.
       });
 
       this.socket.on("message_received", (message: any) => {
-        logger.info("New message received:", message);
+        const parsed = message instanceof ArrayBuffer || message instanceof Uint8Array ? decodeBinaryMessage(message).payload : message;
+        logger.info("New message received:", parsed);
         // TODO: Handle new message
         // This could update chat UI, show message notification, etc.
       });
@@ -98,15 +102,23 @@ class SocketService {
     }
   }
 
-  emit(event: string, data: any) {
+  emit(event: string, data: Record<string, any>) {
     if (this.socket) {
-      this.socket.emit(event, data);
+      const encoded = encodeBinaryMessage(event, data);
+      this.socket.emit(event, encoded);
     }
   }
 
   on(event: string, callback: (data: any) => void) {
     if (this.socket) {
-      this.socket.on(event, callback);
+      this.socket.on(event, (data: any) => {
+        if (data instanceof ArrayBuffer || data instanceof Uint8Array) {
+          const decoded = decodeBinaryMessage(data);
+          callback(decoded.payload);
+          return;
+        }
+        callback(data);
+      });
     }
   }
 


### PR DESCRIPTION
Closes #406

---

### Motivation
- Reduce WebSocket payload size and bandwidth by replacing JSON envelopes with a compact protobuf-style binary envelope for high-frequency real-time events.
- Keep backward compatibility so unknown events and existing JSON payloads continue to work via a JSON fallback.

### Description
- Added `src/services/socket/binaryProtocol.ts` which implements manual varint/fixed64/length-delimited encoding/decoding, event schemas for `notification_created`, `course_updated`, and `message_received`, and `estimatePayloadReduction` to compare JSON vs binary sizes.
- Updated `src/services/socket/index.ts` to `encodeBinaryMessage` on outbound `emit` and to `decodeBinaryMessage` for inbound `ArrayBuffer`/`Uint8Array` frames while preserving existing socket lifecycle and reconnection behavior.
- Added tests at `src/__tests__/services/binaryProtocol.test.ts` that validate known-event round-trip, unknown-event JSON fallback, and payload reduction metrics.
- Documented the protocol shape and usage in `README.md` under the new "WebSocket Binary Protocol" section.

### Testing
- Added unit tests in `src/__tests__/services/binaryProtocol.test.ts` which exercise `encodeBinaryMessage`, `decodeBinaryMessage`, and `estimatePayloadReduction`.

------
