### PR TITLE
feat(store): implement selective persistence with versioning (#384)

### DIFF
--- a/src/store/achievementStore.ts
+++ b/src/store/achievementStore.ts
@@ -1,6 +1,7 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { create } from 'zustand';
-import { createJSONStorage, persist } from 'zustand/middleware';
+import { persist } from 'zustand/middleware';
+
+import { asyncStorageJSONStorage, isRecord, unwrapPersistedState } from './persistence';
 
 /**
  * Rarity levels for achievement badges
@@ -48,6 +49,8 @@ export enum AchievementType {
 interface AchievementState {
   /** Array of all achievements (both locked and unlocked) */
   achievements: Achievement[];
+  /** Persisted unlock/progress data keyed by achievement ID */
+  achievementProgress: Record<string, AchievementProgress>;
   /** Number of unlocked achievements */
   unlockedCount: number;
   
@@ -64,6 +67,12 @@ interface AchievementState {
   resetAchievements: () => void;
   /** Initialize achievements with default set */
   initializeAchievements: (achievements: Achievement[]) => void;
+}
+
+interface AchievementProgress {
+  isLocked?: boolean;
+  unlockedAt?: string;
+  progress?: { current: number; total: number };
 }
 
 /**
@@ -141,10 +150,135 @@ export const DEFAULT_ACHIEVEMENTS: Achievement[] = [
   },
 ];
 
+const DEFAULT_ACHIEVEMENT_BY_ID = Object.fromEntries(
+  DEFAULT_ACHIEVEMENTS.map((achievement) => [achievement.id, achievement]),
+) as Record<string, Achievement>;
+
+function buildAchievementsFromProgress(progressById: Record<string, AchievementProgress>): Achievement[] {
+  return DEFAULT_ACHIEVEMENTS.map((achievement) => {
+    const progress = progressById[achievement.id];
+    if (!progress) {
+      return achievement;
+    }
+
+    return {
+      ...achievement,
+      ...(progress.isLocked !== undefined ? { isLocked: progress.isLocked } : {}),
+      ...(progress.unlockedAt !== undefined ? { unlockedAt: progress.unlockedAt } : {}),
+      ...(progress.progress ? { progress: progress.progress } : {}),
+    };
+  });
+}
+
+function snapshotAchievementProgress(achievements: Achievement[]): Record<string, AchievementProgress> {
+  return achievements.reduce<Record<string, AchievementProgress>>((snapshot, achievement) => {
+    const defaultAchievement = DEFAULT_ACHIEVEMENT_BY_ID[achievement.id];
+    if (!defaultAchievement) {
+      snapshot[achievement.id] = {
+        isLocked: achievement.isLocked,
+        unlockedAt: achievement.unlockedAt,
+        progress: achievement.progress,
+      };
+      return snapshot;
+    }
+
+    const progress: AchievementProgress = {};
+
+    if (achievement.isLocked !== defaultAchievement.isLocked) {
+      progress.isLocked = achievement.isLocked;
+    }
+
+    if (achievement.unlockedAt !== defaultAchievement.unlockedAt) {
+      progress.unlockedAt = achievement.unlockedAt;
+    }
+
+    const currentProgress = achievement.progress;
+    const defaultProgress = defaultAchievement.progress;
+    const progressChanged =
+      (!!currentProgress !== !!defaultProgress) ||
+      (currentProgress !== undefined &&
+        defaultProgress !== undefined &&
+        (currentProgress.current !== defaultProgress.current ||
+          currentProgress.total !== defaultProgress.total));
+
+    if (progressChanged && currentProgress) {
+      progress.progress = currentProgress;
+    }
+
+    if (Object.keys(progress).length > 0) {
+      snapshot[achievement.id] = progress;
+    }
+
+    return snapshot;
+  }, {});
+}
+
+function parseAchievementProgressMap(value: unknown): Record<string, AchievementProgress> {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  return Object.entries(value).reduce<Record<string, AchievementProgress>>((snapshot, [id, entry]) => {
+    if (!isRecord(entry)) {
+      return snapshot;
+    }
+
+    const progress: AchievementProgress = {};
+
+    if (typeof entry.isLocked === 'boolean') {
+      progress.isLocked = entry.isLocked;
+    }
+
+    if (typeof entry.unlockedAt === 'string') {
+      progress.unlockedAt = entry.unlockedAt;
+    }
+
+    if (isRecord(entry.progress)) {
+      const current = entry.progress.current;
+      const total = entry.progress.total;
+      if (typeof current === 'number' && typeof total === 'number') {
+        progress.progress = { current, total };
+      }
+    }
+
+    if (Object.keys(progress).length > 0) {
+      snapshot[id] = progress;
+    }
+
+    return snapshot;
+  }, {});
+}
+
+function normalizeAchievementState(rawState: unknown): {
+  achievements: Achievement[];
+  achievementProgress: Record<string, AchievementProgress>;
+  unlockedCount: number;
+} {
+  const persistedState = unwrapPersistedState<Partial<AchievementState>>(rawState) ?? {};
+  const legacyAchievements = Array.isArray(persistedState.achievements)
+    ? persistedState.achievements
+    : null;
+  const persistedProgress = parseAchievementProgressMap(persistedState.achievementProgress);
+  const legacyProgress = legacyAchievements ? snapshotAchievementProgress(legacyAchievements) : {};
+  const mergedProgress = { ...legacyProgress, ...persistedProgress };
+  const achievements = buildAchievementsFromProgress(mergedProgress);
+  const unlockedCount =
+    typeof persistedState.unlockedCount === 'number'
+      ? persistedState.unlockedCount
+      : achievements.filter((achievement) => !achievement.isLocked).length;
+
+  return {
+    achievements,
+    achievementProgress: mergedProgress,
+    unlockedCount,
+  };
+}
+
 export const useAchievementStore = create<AchievementState>()(
   persist(
     (set, get) => ({
-      achievements: DEFAULT_ACHIEVEMENTS,
+      achievements: buildAchievementsFromProgress({}),
+      achievementProgress: {},
       unlockedCount: 0,
 
       unlockAchievement: (id: string) =>
@@ -167,6 +301,7 @@ export const useAchievementStore = create<AchievementState>()(
 
           return {
             achievements: updatedAchievements,
+            achievementProgress: snapshotAchievementProgress(updatedAchievements),
             unlockedCount: updatedAchievements.filter((a) => !a.isLocked).length,
           };
         }),
@@ -199,6 +334,7 @@ export const useAchievementStore = create<AchievementState>()(
 
           return {
             achievements: updatedAchievements,
+            achievementProgress: snapshotAchievementProgress(updatedAchievements),
             unlockedCount: updatedAchievements.filter((a) => !a.isLocked).length,
           };
         }),
@@ -214,23 +350,34 @@ export const useAchievementStore = create<AchievementState>()(
 
       resetAchievements: () =>
         set({
-          achievements: DEFAULT_ACHIEVEMENTS,
+          achievements: buildAchievementsFromProgress({}),
+          achievementProgress: {},
           unlockedCount: 0,
         }),
 
       initializeAchievements: (achievements: Achievement[]) =>
         set({
           achievements,
+          achievementProgress: snapshotAchievementProgress(achievements),
           unlockedCount: achievements.filter((a) => !a.isLocked).length,
         }),
     }),
     {
       name: 'achievement-storage',
-      storage: createJSONStorage(() => AsyncStorage),
+      version: 1,
+      storage: asyncStorageJSONStorage,
       partialize: (state) => ({
-        achievements: state.achievements,
+        achievementProgress: state.achievementProgress,
         unlockedCount: state.unlockedCount,
       }),
-    }
+      migrate: (persistedState) => normalizeAchievementState(persistedState),
+      merge: (persistedState, currentState) => {
+        const normalizedState = normalizeAchievementState(persistedState);
+        return {
+          ...currentState,
+          ...normalizedState,
+        };
+      },
+    },
   )
 );

--- a/src/store/courseProgressStore.ts
+++ b/src/store/courseProgressStore.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 import type { CourseProgress } from '../types/course';
+import { asyncStorageJSONStorage } from './persistence';
 
 interface CourseProgressState {
   // keyed by courseId
@@ -9,11 +11,23 @@ interface CourseProgressState {
   getCourseProgress: (courseId: string) => CourseProgress | null;
 }
 
-export const useCourseProgressStore = create<CourseProgressState>((set, get) => ({
-  progressMap: {},
+export const useCourseProgressStore = create<CourseProgressState>()(
+  persist(
+    (set, get) => ({
+      progressMap: {},
 
-  setCourseProgress: (courseId, progress) =>
-    set((s) => ({ progressMap: { ...s.progressMap, [courseId]: progress } })),
+      setCourseProgress: (courseId, progress) =>
+        set((s) => ({ progressMap: { ...s.progressMap, [courseId]: progress } })),
 
-  getCourseProgress: (courseId) => get().progressMap[courseId] ?? null,
-}));
+      getCourseProgress: (courseId) => get().progressMap[courseId] ?? null,
+    }),
+    {
+      name: 'course-progress-storage',
+      version: 1,
+      storage: asyncStorageJSONStorage,
+      partialize: (state) => ({
+        progressMap: state.progressMap,
+      }),
+    },
+  ),
+);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,6 +3,7 @@ import { create } from 'zustand';
 import { createJSONStorage, devtools, persist, subscribeWithSelector } from 'zustand/middleware';
 
 import type { StateStorage } from 'zustand/middleware';
+import { toUnixMs } from './persistence';
 
 export interface User {
   id: string;
@@ -26,7 +27,7 @@ interface AppState {
   error: string | null;
   setUser: (user: User | null) => void;
   setTheme: (theme: 'light' | 'dark') => void;
-  setTokens: (accessToken: string, refreshToken: string, expiresAt: number) => void;
+  setTokens: (accessToken: string, refreshToken: string, expiresAt: number | Date) => void;
   setSessionExpiringSoon: (isExpiringSoon: boolean) => void;
   setAuthLoading: (isAuthLoading: boolean) => void;
   setAuthError: (authError: string | null) => void;
@@ -70,7 +71,15 @@ export const useAppStore = create<AppState>()(
         setUser: (user) => set({ user, isAuthenticated: !!user }, false, 'setUser'),
         setTheme: (theme) => set({ theme }, false, 'setTheme'),
         setTokens: (accessToken, refreshToken, sessionExpiresAt) =>
-          set({ accessToken, refreshToken, sessionExpiresAt }, false, 'setTokens'),
+          set(
+            {
+              accessToken,
+              refreshToken,
+              sessionExpiresAt: toUnixMs(sessionExpiresAt),
+            },
+            false,
+            'setTokens'
+          ),
         setSessionExpiringSoon: (sessionExpiringSoon) =>
           set({ sessionExpiringSoon }, false, 'setSessionExpiringSoon'),
         setAuthLoading: (isAuthLoading) => set({ isAuthLoading }, false, 'setAuthLoading'),
@@ -106,9 +115,18 @@ export const useAppStore = create<AppState>()(
           isAuthenticated: state.isAuthenticated,
           accessToken: state.accessToken,
           refreshToken: state.refreshToken,
-          sessionExpiresAt: state.sessionExpiresAt,
+          sessionExpiresAt: toUnixMs(state.sessionExpiresAt),
           theme: state.theme,
         }),
+        merge: (persistedState, currentState) => {
+          const hydratedState = (persistedState ?? {}) as Partial<AppState>;
+
+          return {
+            ...currentState,
+            ...hydratedState,
+            sessionExpiresAt: toUnixMs(hydratedState.sessionExpiresAt),
+          };
+        },
       }
     ),
     { name: 'AppStore' }

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -1,0 +1,89 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
+import { createJSONStorage, type StateStorage } from 'zustand/middleware';
+
+export interface VersionedEnvelope<T> {
+  version: number;
+  data: T;
+}
+
+export const asyncStorageJSONStorage = createJSONStorage(() => AsyncStorage);
+
+const secureStorageAdapter: StateStorage = {
+  getItem: async (name: string) => {
+    const value = await SecureStore.getItemAsync(name);
+    return value ?? null;
+  },
+  setItem: async (name: string, value: string) => {
+    await SecureStore.setItemAsync(name, value);
+  },
+  removeItem: async (name: string) => {
+    await SecureStore.deleteItemAsync(name);
+  },
+};
+
+export const secureStorageJSONStorage = createJSONStorage(() => secureStorageAdapter);
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function unwrapPersistedState<T>(value: unknown): T | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  if ('state' in value && isRecord(value.state)) {
+    return value.state as T;
+  }
+
+  return value as T;
+}
+
+export function toUnixMs(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+
+  return null;
+}
+
+export async function readVersionedJson<T>(key: string): Promise<T | null> {
+  const rawValue = await AsyncStorage.getItem(key);
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue) as unknown;
+    if (isRecord(parsed) && 'version' in parsed && 'data' in parsed) {
+      return parsed.data as T;
+    }
+
+    return parsed as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeVersionedJson<T>(key: string, data: T, version: number): Promise<void> {
+  const envelope: VersionedEnvelope<T> = { version, data };
+  await AsyncStorage.setItem(key, JSON.stringify(envelope));
+}
+
+export async function removeStorageKeys(keys: string[]): Promise<void> {
+  if (keys.length === 0) {
+    return;
+  }
+
+  await AsyncStorage.multiRemove(keys);
+}

--- a/src/store/quizStore.ts
+++ b/src/store/quizStore.ts
@@ -1,10 +1,18 @@
 import { create } from 'zustand';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Quiz, Question, QuizProgress } from '../types/course';
+import { Quiz, QuizProgress } from '../types/course';
 import logger from '../utils/logger';
+import { isRecord } from './persistence';
 
 const QUIZ_SESSION_KEY = '@teachlink_quiz_session';
 const QUIZ_PROGRESS_KEY = '@teachlink_quiz_progress';
+const QUIZ_STORAGE_VERSION = 1;
+const QUIZ_STORAGE_MIGRATED_KEY = '@teachlink_quiz_storage_migrated_v1';
+
+interface VersionedQuizEnvelope<T> {
+  version: number;
+  data: T;
+}
 
 interface QuizSession {
   quizId: string | null;
@@ -13,6 +21,89 @@ interface QuizSession {
   currentQuestionIndex: number;
   selectedAnswers: Record<string, string | number | (string | number)[]>; // questionId -> answer(s)
   startedAt: string | null;
+}
+
+function isVersionedQuizEnvelope<T>(value: unknown): value is VersionedQuizEnvelope<T> {
+  return isRecord(value) && typeof value.version === 'number' && 'data' in value;
+}
+
+async function readQuizStorage<T>(key: string): Promise<T | null> {
+  const rawValue = await AsyncStorage.getItem(key);
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue) as unknown;
+    if (isVersionedQuizEnvelope<T>(parsed)) {
+      return parsed.data;
+    }
+
+    return parsed as T;
+  } catch {
+    return null;
+  }
+}
+
+async function writeVersionedQuizStorage<T>(key: string, data: T): Promise<void> {
+  const envelope: VersionedQuizEnvelope<T> = {
+    version: QUIZ_STORAGE_VERSION,
+    data,
+  };
+
+  await AsyncStorage.setItem(key, JSON.stringify(envelope));
+}
+
+async function ensureQuizStorageMigrated(): Promise<void> {
+  const migrationMarker = await AsyncStorage.getItem(QUIZ_STORAGE_MIGRATED_KEY);
+  if (migrationMarker) {
+    return;
+  }
+
+  const allKeys = await AsyncStorage.getAllKeys();
+  const legacyKeys = allKeys.filter(
+    (key) => key === QUIZ_SESSION_KEY || key.startsWith(`${QUIZ_PROGRESS_KEY}_`)
+  );
+
+  for (const key of legacyKeys) {
+    const rawValue = await AsyncStorage.getItem(key);
+    if (!rawValue) {
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(rawValue) as unknown;
+      if (isVersionedQuizEnvelope(parsed)) {
+        continue;
+      }
+
+      await AsyncStorage.setItem(
+        key,
+        JSON.stringify({
+          version: QUIZ_STORAGE_VERSION,
+          data: parsed,
+        } as VersionedQuizEnvelope<unknown>)
+      );
+    } catch {
+      // Ignore malformed legacy values; the migration marker still prevents retries.
+    }
+  }
+
+  await AsyncStorage.setItem(QUIZ_STORAGE_MIGRATED_KEY, String(QUIZ_STORAGE_VERSION));
+}
+
+function persistQuizSession(session: QuizSession): void {
+  void ensureQuizStorageMigrated()
+    .then(() => writeVersionedQuizStorage(QUIZ_SESSION_KEY, session))
+    .catch((error) => logger.error('Error saving quiz session:', error));
+}
+
+async function saveQuizProgress(
+  courseId: string,
+  quizProgress: Record<string, QuizProgress>,
+): Promise<void> {
+  await ensureQuizStorageMigrated();
+  await writeVersionedQuizStorage(`${QUIZ_PROGRESS_KEY}_${courseId}`, quizProgress);
 }
 
 interface QuizState {
@@ -48,6 +139,7 @@ export const useQuizStore = create<QuizState>((set, get) => ({
 
   startQuiz: async (quizId: string, sectionId: string, courseId: string) => {
     try {
+      await ensureQuizStorageMigrated();
       const newSession: QuizSession = {
         quizId,
         sectionId,
@@ -60,7 +152,7 @@ export const useQuizStore = create<QuizState>((set, get) => ({
       set({ session: newSession });
 
       // Save session to AsyncStorage
-      await AsyncStorage.setItem(QUIZ_SESSION_KEY, JSON.stringify(newSession));
+      await writeVersionedQuizStorage(QUIZ_SESSION_KEY, newSession);
       
       logger.info('Quiz started:', { quizId, sectionId, courseId });
     } catch (error) {
@@ -89,15 +181,12 @@ export const useQuizStore = create<QuizState>((set, get) => ({
         // If array becomes empty, remove the key
         if (updatedAnswer.length === 0) {
           const { [questionId]: _, ...rest } = session.selectedAnswers;
-          updatedAnswer = undefined as any;
           const updatedSession: QuizSession = {
             ...session,
             selectedAnswers: rest,
           };
           set({ session: updatedSession });
-          AsyncStorage.setItem(QUIZ_SESSION_KEY, JSON.stringify(updatedSession)).catch(
-            (error) => logger.error('Error saving quiz session:', error)
-          );
+          persistQuizSession(updatedSession);
           return;
         }
       } else {
@@ -122,9 +211,7 @@ export const useQuizStore = create<QuizState>((set, get) => ({
     set({ session: updatedSession });
 
     // Auto-save session
-    AsyncStorage.setItem(QUIZ_SESSION_KEY, JSON.stringify(updatedSession)).catch(
-      (error) => logger.error('Error saving quiz session:', error)
-    );
+    persistQuizSession(updatedSession);
   },
 
   goToQuestion: (index: number) => {
@@ -136,9 +223,7 @@ export const useQuizStore = create<QuizState>((set, get) => ({
       };
       set({ session: updatedSession });
       
-      AsyncStorage.setItem(QUIZ_SESSION_KEY, JSON.stringify(updatedSession)).catch(
-        (error) => logger.error('Error saving quiz session:', error)
-      );
+      persistQuizSession(updatedSession);
     }
   },
 
@@ -150,8 +235,8 @@ export const useQuizStore = create<QuizState>((set, get) => ({
     }
 
     try {
+      await ensureQuizStorageMigrated();
       // Calculate score
-      let correctCount = 0;
       let totalPoints = 0;
       let earnedPoints = 0;
 
@@ -185,7 +270,6 @@ export const useQuizStore = create<QuizState>((set, get) => ({
           }
 
           if (isCorrect) {
-            correctCount++;
             earnedPoints += question.points;
           }
         }
@@ -220,8 +304,7 @@ export const useQuizStore = create<QuizState>((set, get) => ({
       set({ quizProgress: updatedProgress });
 
       // Save to AsyncStorage
-      const storageKey = `${QUIZ_PROGRESS_KEY}_${session.courseId}`;
-      await AsyncStorage.setItem(storageKey, JSON.stringify(updatedProgress));
+      await saveQuizProgress(session.courseId, updatedProgress);
 
       // Clear session
       await AsyncStorage.removeItem(QUIZ_SESSION_KEY);
@@ -238,6 +321,7 @@ export const useQuizStore = create<QuizState>((set, get) => ({
 
   resetSession: async () => {
     try {
+      await ensureQuizStorageMigrated();
       await AsyncStorage.removeItem(QUIZ_SESSION_KEY);
       set({ session: initialSession });
     } catch (error) {
@@ -247,20 +331,19 @@ export const useQuizStore = create<QuizState>((set, get) => ({
 
   loadQuizProgress: async (courseId: string) => {
     try {
+      await ensureQuizStorageMigrated();
       const storageKey = `${QUIZ_PROGRESS_KEY}_${courseId}`;
-      const stored = await AsyncStorage.getItem(storageKey);
+      const stored = await readQuizStorage<Record<string, QuizProgress>>(storageKey);
       
       if (stored) {
-        const parsed = JSON.parse(stored) as Record<string, QuizProgress>;
-        set({ quizProgress: parsed });
+        set({ quizProgress: stored });
       } else {
         set({ quizProgress: {} });
       }
 
       // Also try to restore active session if exists
-      const sessionData = await AsyncStorage.getItem(QUIZ_SESSION_KEY);
-      if (sessionData) {
-        const session = JSON.parse(sessionData) as QuizSession;
+      const session = await readQuizStorage<QuizSession>(QUIZ_SESSION_KEY);
+      if (session) {
         // Only restore if it's for the current course
         if (session.courseId === courseId) {
           set({ session });

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -117,7 +117,24 @@ export const useSettingsStore = create<SettingsState>()(
     }),
     {
       name: 'settings-storage',
+      version: 1,
       storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({
+        profileVisibility: state.profileVisibility,
+        twoFactorEnabled: state.twoFactorEnabled,
+        dataSharing: state.dataSharing,
+        analyticsEnabled: state.analyticsEnabled,
+        locationServices: state.locationServices,
+        downloadOverWifiOnly: state.downloadOverWifiOnly,
+        autoDownload: state.autoDownload,
+        downloadQuality: state.downloadQuality,
+        storageLimit: state.storageLimit,
+        language: state.language,
+        fontSize: state.fontSize,
+        autoplay: state.autoplay,
+        hapticFeedback: state.hapticFeedback,
+      }),
+      migrate: (persistedState) => (persistedState ?? {}) as Partial<SettingsState>,
     }
   )
 );


### PR DESCRIPTION
Closes #384

Summary
The app was either persisting too much, too little, or using raw AsyncStorage calls with no versioning. This PR tightens that up across the store layer.

What I did
Created a shared `persistence.ts` utility to centralize storage helpers: versioned read/write helpers, `toUnixMs` for safe date normalization, and a reusable AsyncStorage JSON adapter.

Then I went store by store:

- `achievementStore` was writing the full achievements array to disk, including static metadata like names, emojis, and descriptions. Now only progress state is persisted, and static data is rebuilt from code on rehydration.
- `courseProgressStore` had no persistence at all, so users were losing course progress on app restart. Added Zustand `persist` with an explicit `partialize`.
- `settingsStore` was missing `partialize`, so the store had no explicit data whitelist. Added one to persist only settings fields.
- `quizStore` was using raw `AsyncStorage.setItem` calls with no versioning. Replaced that with versioned helpers and added a one-time, idempotent migration from legacy `@teachlink_*` keys.
- `index.ts` now normalizes `sessionExpiresAt` to Unix milliseconds at write and hydrate time so it never persists as a `Date` object.
