### PR TITLE
feat: implement automatic route-size based code splitting heuristics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ expo-env.d.ts
 
 # Metro
 .metro-health-check*
+.metro-route-sizes.json
+
+# Route size analysis reports
+.route-size-report.json
 
 # debug
 npm-debug.*

--- a/app/qr-scanner.tsx
+++ b/app/qr-scanner.tsx
@@ -1,8 +1,9 @@
 import { useRouter } from 'expo-router';
-import React from 'react';
-import { Alert, View } from 'react-native';
-import QRScanner from '@/src/components/mobile/QRScanner';
+import React, { Suspense } from 'react';
+import { ActivityIndicator, Alert, StyleSheet, View } from 'react-native';
 import { getPathFromDeepLink, parseDeepLinkUrl } from '@/src/utils/linkParser';
+
+const QRScanner = React.lazy(() => import('@/src/components/mobile/QRScanner'));
 
 export default function QRScannerScreen() {
   const router = useRouter();
@@ -19,8 +20,16 @@ export default function QRScannerScreen() {
   };
 
   return (
-    <View style={{ flex: 1 }}>
-      <QRScanner onLinkScanned={handleLinkScanned} />
+    <View style={styles.container}>
+      <Suspense fallback={<ActivityIndicator style={StyleSheet.absoluteFill} size="large" />}>
+        <QRScanner onLinkScanned={handleLinkScanned} />
+      </Suspense>
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,6 +1,167 @@
 const { getDefaultConfig } = require('expo/metro-config');
 const { withNativeWind } = require('nativewind/metro');
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Auto code-splitting: route size threshold
+// Routes whose synchronous dependency chunk exceeds this value trigger a
+// warning and are recorded in .metro-route-sizes.json for CI inspection.
+// ---------------------------------------------------------------------------
+const ROUTE_SIZE_THRESHOLD = 100 * 1024; // 100 KB
+
+/**
+ * Walks the synchronous dependency sub-graph rooted at `entryPath` and
+ * returns the total compiled byte size of every non-dynamic module.
+ *
+ * Metro marks dynamic import() edges with asyncType !== null, so those
+ * subtrees (i.e. React.lazy chunks) are correctly excluded from the count.
+ *
+ * @param {string} entryPath
+ * @param {Map<string, import('metro').Module>} allModules
+ * @returns {{ bytes: number, moduleCount: number }}
+ */
+function computeRouteSyncChunkSize(entryPath, allModules) {
+  const visited = new Set();
+  let bytes = 0;
+
+  function visit(modulePath) {
+    if (visited.has(modulePath)) return;
+    visited.add(modulePath);
+
+    const mod = allModules.get(modulePath);
+    if (!mod) return;
+
+    for (const output of mod.output ?? []) {
+      if (output.data?.code) {
+        bytes += Buffer.byteLength(output.data.code, 'utf8');
+      }
+    }
+
+    for (const dep of mod.dependencies?.values() ?? []) {
+      // asyncType: null → synchronous import (count it)
+      // asyncType: 'async' | 'prefetch' → dynamic import() boundary (skip)
+      if (dep.data?.data?.asyncType == null) {
+        visit(dep.absolutePath);
+      }
+    }
+  }
+
+  visit(entryPath);
+  return { bytes, moduleCount: visited.size };
+}
+
+/**
+ * Iterates the Metro module graph, identifies Expo Router route files
+ * (any .ts/.tsx/.js/.jsx under app/), and logs a warning for every route
+ * whose synchronous chunk exceeds ROUTE_SIZE_THRESHOLD.
+ *
+ * Results are written to .metro-route-sizes.json so CI and bundle auditing
+ * tools can consume them without re-parsing console output.
+ *
+ * @param {import('metro/src/DeltaBundler').ReadOnlyGraph} graph
+ */
+function analyzeRouteChunkSizes(graph) {
+  const projectRoot = __dirname;
+  const appPrefix = path.join(projectRoot, 'app') + path.sep;
+  const results = [];
+
+  for (const modulePath of graph.dependencies.keys()) {
+    if (!modulePath.startsWith(appPrefix)) continue;
+    if (modulePath.includes('node_modules')) continue;
+    if (!/\.(tsx?|jsx?)$/.test(modulePath)) continue;
+
+    const { bytes, moduleCount } = computeRouteSyncChunkSize(
+      modulePath,
+      graph.dependencies,
+    );
+
+    const route = path.relative(projectRoot, modulePath);
+    const exceeds = bytes > ROUTE_SIZE_THRESHOLD;
+    results.push({ route, bytes, moduleCount, exceeds });
+
+    if (exceeds) {
+      const kb = (bytes / 1024).toFixed(1);
+      console.warn(
+        `\n⚠️   [auto-split] Route chunk exceeds 100 KB threshold\n` +
+          `    Route     : ${route}\n` +
+          `    Sync size : ${kb} KB  (${moduleCount} modules)\n` +
+          `    Fix       : use React.lazy() for heavy component imports\n`,
+      );
+    }
+  }
+
+  if (results.length === 0) return;
+
+  try {
+    fs.writeFileSync(
+      path.join(projectRoot, '.metro-route-sizes.json'),
+      JSON.stringify(
+        {
+          threshold: ROUTE_SIZE_THRESHOLD,
+          generatedAt: new Date().toISOString(),
+          routes: results,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch {
+    // Non-fatal: report write failure must not break the build
+  }
+}
+
+/**
+ * Wraps an existing serializer (or Metro's default) with the route-size
+ * analysis pass. The analysis is a pure side-effect observer — the bundle
+ * output is not modified.
+ *
+ * @param {Function|undefined} existingSerializer
+ * @returns {Function}
+ */
+function wrapWithRouteSizeAnalyzer(existingSerializer) {
+  return async function routeSizeAnalyzerSerializer(
+    entryPoint,
+    preModules,
+    graph,
+    options,
+  ) {
+    try {
+      analyzeRouteChunkSizes(graph);
+    } catch (err) {
+      // Analysis errors must never break the bundle
+      console.warn('[auto-split] Route size analysis failed:', err.message);
+    }
+
+    // Delegate to the upstream serializer if one exists (e.g. Expo's or NativeWind's).
+    if (typeof existingSerializer === 'function') {
+      return existingSerializer(entryPoint, preModules, graph, options);
+    }
+
+    // No upstream serializer — call Metro's built-in bundler directly.
+    // These module paths are stable across Metro 0.76–0.82 (Expo SDK 50–54).
+    const { default: baseJSBundle } = require('metro/src/DeltaBundler/Serializers/baseJSBundle');
+    const { default: bundleToString } = require('metro/src/DeltaBundler/Serializers/bundleToString');
+    const { code } = bundleToString(
+      baseJSBundle(entryPoint, preModules, graph, options),
+    );
+    return code;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Compose the final Metro config
+// ---------------------------------------------------------------------------
 
 const config = getDefaultConfig(__dirname);
 
-module.exports = withNativeWind(config, { input: './global.css' });
+// Apply NativeWind first so we capture its serializer (if any) before wrapping.
+const nativewindConfig = withNativeWind(config, { input: './global.css' });
+
+// Inject the route size analysis observer into the serializer chain.
+nativewindConfig.serializer ??= {};
+nativewindConfig.serializer.customSerializer = wrapWithRouteSizeAnalyzer(
+  nativewindConfig.serializer.customSerializer,
+);
+
+module.exports = nativewindConfig;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "audit": "npm audit --audit-level=high",
     "depcheck": "depcheck",
     "perf:bundle": "node scripts/checkBundleSize.js",
-    "perf:api": "node scripts/checkApiPerf.js"
+    "perf:api": "node scripts/checkApiPerf.js",
+    "analyze:routes": "node scripts/analyzeRouteSizes.js",
+    "analyze:routes:report": "node scripts/analyzeRouteSizes.js --report"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",

--- a/scripts/analyzeRouteSizes.js
+++ b/scripts/analyzeRouteSizes.js
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+/**
+ * Route Size Analyzer
+ *
+ * Statically walks the import graph starting from every Expo Router route file
+ * under app/ and measures the transitive *synchronous* source size of each route.
+ * Routes whose sync chunk exceeds the 100 KB threshold must use React.lazy() to
+ * split heavy component imports dynamically, or the script exits non-zero.
+ *
+ * Usage:
+ *   node scripts/analyzeRouteSizes.js          # analyse + enforce
+ *   node scripts/analyzeRouteSizes.js --report  # analyse only, never exits 1
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const APP_DIR = path.join(PROJECT_ROOT, 'app');
+const THRESHOLD_BYTES = 100 * 1024; // 100 KB
+
+const REPORT_ONLY = process.argv.includes('--report');
+
+// Module resolution – mirrors Metro/babel-preset-expo conventions.
+// Metro (via babel-preset-expo) maps `@` to the project root, so:
+//   @/src/components/... → ./src/components/...
+//   @/components/...     → ./components/...
+// This differs from tsconfig paths (./src/*) which only affect the TS checker.
+const ALIAS_MAP = {
+  '@': PROJECT_ROOT,
+};
+
+// Component directories that map to the root (expo uses bare component/ at root)
+const ROOT_DIRS = ['components', 'constants', 'hooks', 'assets'];
+
+const EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js'];
+
+// ---------------------------------------------------------------------------
+// Module resolution
+// ---------------------------------------------------------------------------
+
+/** @returns {string|null} absolute resolved file path, or null */
+function resolveModule(specifier, fromFile) {
+  // Skip node_modules and built-ins
+  if (!specifier.startsWith('.') && !specifier.startsWith('/')) {
+    // Check aliases
+    let mapped = null;
+    for (const [alias, target] of Object.entries(ALIAS_MAP)) {
+      if (alias.endsWith('/')) {
+        if (specifier.startsWith(alias)) {
+          mapped = path.join(target, specifier.slice(alias.length));
+          break;
+        }
+      } else {
+        if (specifier === alias || specifier.startsWith(alias + '/')) {
+          mapped = path.join(target, specifier.slice(alias.length).replace(/^\//, ''));
+          break;
+        }
+      }
+    }
+
+    if (!mapped) {
+      // Check if it's a root-level directory alias (components/, constants/, etc.)
+      const firstSegment = specifier.split('/')[0];
+      if (ROOT_DIRS.includes(firstSegment)) {
+        mapped = path.join(PROJECT_ROOT, specifier);
+      }
+    }
+
+    if (!mapped) return null; // external package
+    specifier = mapped;
+  } else {
+    specifier = path.resolve(path.dirname(fromFile), specifier);
+  }
+
+  return tryResolveFile(specifier);
+}
+
+function tryResolveFile(base) {
+  // Exact path with extension
+  if (fs.existsSync(base) && fs.statSync(base).isFile()) return base;
+
+  // Try adding extensions
+  for (const ext of EXTENSIONS) {
+    const candidate = base + ext;
+    if (fs.existsSync(candidate)) return candidate;
+  }
+
+  // Try as a directory index
+  for (const ext of EXTENSIONS) {
+    const candidate = path.join(base, 'index' + ext);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Import parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns { staticImports: string[], dynamicImports: string[] } for a file.
+ * staticImports  → counted in the synchronous chunk
+ * dynamicImports → lazy-loaded; excluded from the sync chunk
+ */
+function parseImports(filePath) {
+  let content;
+  try {
+    content = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return { staticImports: [], dynamicImports: [] };
+  }
+
+  const staticImports = new Set();
+  const dynamicImports = new Set();
+
+  // 1. Named / default / namespace / side-effect static imports
+  //    import X from '...'  |  import { X } from '...'  |  import '...'
+  const staticImportRe =
+    /^\s*import\s+(?:(?:[\w$*{},\s]+)\s+from\s+)?['"]([^'"]+)['"]/gm;
+  let m;
+  while ((m = staticImportRe.exec(content)) !== null) {
+    staticImports.add(m[1]);
+  }
+
+  // 2. CommonJS require (non-dynamic context)
+  //    const X = require('...')   — only if not inside an arrow/function literal
+  const requireRe = /\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+  while ((m = requireRe.exec(content)) !== null) {
+    staticImports.add(m[1]);
+  }
+
+  // 3. Dynamic import() — these mark a lazy boundary
+  //    import('...')  |  React.lazy(() => import('...'))
+  const dynamicImportRe = /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+  while ((m = dynamicImportRe.exec(content)) !== null) {
+    dynamicImports.add(m[1]);
+    // Remove from static if wrongly captured above (rare edge-case with multiline)
+    staticImports.delete(m[1]);
+  }
+
+  // 4. require.resolveWeak (Metro async boundary)
+  const resolveWeakRe = /require\.resolveWeak\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+  while ((m = resolveWeakRe.exec(content)) !== null) {
+    dynamicImports.add(m[1]);
+    staticImports.delete(m[1]);
+  }
+
+  return {
+    staticImports: [...staticImports],
+    dynamicImports: [...dynamicImports],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Transitive sync-chunk analysis
+// ---------------------------------------------------------------------------
+
+/**
+ * @returns {{ bytes: number, fileCount: number, dynamicBoundaries: Set<string> }}
+ */
+function computeChunkSize(entryPath) {
+  const visited = new Set();
+  const dynamicBoundaries = new Set();
+  let totalBytes = 0;
+
+  function traverse(filePath) {
+    if (visited.has(filePath)) return;
+    if (filePath.includes('node_modules')) return;
+    visited.add(filePath);
+
+    try {
+      totalBytes += fs.statSync(filePath).size;
+    } catch {
+      // Skip unreadable files
+    }
+
+    const { staticImports, dynamicImports } = parseImports(filePath);
+
+    for (const spec of dynamicImports) {
+      const resolved = resolveModule(spec, filePath);
+      if (resolved) dynamicBoundaries.add(resolved);
+    }
+
+    for (const spec of staticImports) {
+      const resolved = resolveModule(spec, filePath);
+      if (resolved && !dynamicBoundaries.has(resolved)) {
+        traverse(resolved);
+      }
+    }
+  }
+
+  traverse(entryPath);
+  return { bytes: totalBytes, fileCount: visited.size, dynamicBoundaries };
+}
+
+// ---------------------------------------------------------------------------
+// Route discovery
+// ---------------------------------------------------------------------------
+
+function findRouteFiles(dir) {
+  const routes = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return routes;
+  }
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      routes.push(...findRouteFiles(fullPath));
+    } else if (entry.isFile() && /\.(tsx|ts|jsx|js)$/.test(entry.name)) {
+      routes.push(fullPath);
+    }
+  }
+  return routes;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const routeFiles = findRouteFiles(APP_DIR);
+let violations = 0;
+const results = [];
+
+console.log('\n\u{1F4E6}  Route Size Analysis  (threshold: 100 KB)\n');
+console.log('─'.repeat(64));
+
+for (const routeFile of routeFiles) {
+  const rel = path.relative(PROJECT_ROOT, routeFile);
+  const { bytes, fileCount, dynamicBoundaries } = computeChunkSize(routeFile);
+  const sizeKB = (bytes / 1024).toFixed(1);
+  const exceeds = bytes > THRESHOLD_BYTES;
+
+  results.push({ route: rel, bytes, fileCount, dynamicBoundaries: dynamicBoundaries.size, exceeds });
+
+  if (exceeds) {
+    violations++;
+    console.log(`\n❌  ${rel}`);
+    console.log(`     Sync chunk : ${sizeKB} KB  (${fileCount} files, ${dynamicBoundaries.size} lazy boundaries)`);
+    console.log(`     Fix        : wrap heavy imports with React.lazy(() => import('...'))`);
+  } else {
+    const lazy = dynamicBoundaries.size > 0 ? `  ✔ ${dynamicBoundaries.size} lazy` : '';
+    console.log(`✅  ${rel}  —  ${sizeKB} KB  (${fileCount} files${lazy})`);
+  }
+}
+
+console.log('\n' + '─'.repeat(64));
+console.log(
+  `\nRoutes: ${routeFiles.length}   Violations: ${violations}   ` +
+    `Threshold: ${(THRESHOLD_BYTES / 1024).toFixed(0)} KB\n`,
+);
+
+// Write JSON report regardless of exit status
+const reportPath = path.join(PROJECT_ROOT, '.route-size-report.json');
+fs.writeFileSync(
+  reportPath,
+  JSON.stringify(
+    {
+      threshold: THRESHOLD_BYTES,
+      generatedAt: new Date().toISOString(),
+      summary: { total: routeFiles.length, violations },
+      routes: results,
+    },
+    null,
+    2,
+  ),
+);
+console.log(`Report → ${path.relative(PROJECT_ROOT, reportPath)}\n`);
+
+if (!REPORT_ONLY && violations > 0) {
+  console.error(
+    `\u{1F6A8}  ${violations} route(s) exceed 100 KB. ` +
+      `Apply React.lazy() splitting or run with --report to suppress exit code.\n`,
+  );
+  process.exit(1);
+}
+
+if (violations === 0) {
+  console.log('✨  All routes are within the 100 KB threshold.\n');
+}


### PR DESCRIPTION
Closes #400

---

 Adds a Metro serializer plugin and a standalone static-analysis script that
  enforce a 100 KB synchronous-chunk threshold per Expo Router route.

  - metro.config.js: inject wrapWithRouteSizeAnalyzer() into the serializer
    chain after NativeWind; at bundle time it walks each route's sync
    dependency sub-graph (skipping React.lazy/import() edges via asyncType),
    warns for routes exceeding 100 KB, and writes .metro-route-sizes.json
  - scripts/analyzeRouteSizes.js: zero-dependency static analysis tool that
    traverses import trees from every app/ route, detects lazy boundaries, and
    exits non-zero on violations (CI-friendly); --report flag suppresses exit
  - app/qr-scanner.tsx: convert eager QRScanner import to React.lazy() +
    Suspense with ActivityIndicator fallback (the one route missing splitting)
  - package.json: add analyze:routes and analyze:routes:report npm scripts
  - .gitignore: ignore .metro-route-sizes.json and .route-size-report.json"