### PR TITLE
Implement A/B testing framework

### DIFF
--- a/docs/AB_TESTING.md
+++ b/docs/AB_TESTING.md
@@ -1,0 +1,33 @@
+# A/B Testing Process
+
+TeachLink mobile uses `abTestingService` to assign users to experiment variants, track exposure, record metrics per variant, and evaluate statistical significance.
+
+## Create an Experiment
+
+1. Add an `ExperimentConfig` with at least two variants and positive weights.
+2. Register the experiment through `abTestingService.registerExperiment` or add it to `performanceExperiments`.
+3. Use a stable assignment key such as `userId`. Anonymous flows can pass a device or session identifier.
+4. Call `trackExposure` when the user can experience the variant.
+5. Call `trackMetric` for outcome metrics. Performance experiments should use durations, counts, or failure rates that are already meaningful to the team.
+
+## Analyze Results
+
+Use `calculateMetricSignificance` for numeric samples such as render duration, startup time, or image prefetch duration. Use `calculateConversionSignificance` for rates such as completion or error-free sessions.
+
+Before shipping a winning variant:
+
+- Confirm the primary metric is statistically significant at the agreed confidence level.
+- Check guardrail metrics such as crash rate, API errors, and session length.
+- Keep assignment stable until the experiment is stopped.
+- Document the decision and remove stale experiment code after rollout.
+
+## Current Performance Experiment
+
+`image_prefetch_delay_v1` compares immediate image prefetching against a short delay. The goal is to measure whether delaying non-critical prefetch work improves startup and image prefetch duration without increasing failed prefetches.
+
+Team training checklist:
+
+- Review how variant assignment is deterministic and persisted.
+- Review exposure tracking versus metric tracking.
+- Review p-values, confidence level, and the difference between statistical and product significance.
+- Practice reading the `image_prefetch_delay_v1` test as a template for future performance experiments.

--- a/src/services/abTesting.ts
+++ b/src/services/abTesting.ts
@@ -1,0 +1,324 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import mobileAnalyticsService from './mobileAnalytics';
+import logger from '../utils/logger';
+import { AnalyticsEvent, EventProperties } from '../utils/trackingEvents';
+
+const ASSIGNMENT_STORAGE_PREFIX = '@teachlink_ab_assignment';
+const DEFAULT_ALPHA = 0.05;
+
+export interface ExperimentVariant {
+  id: string;
+  name: string;
+  weight: number;
+  description?: string;
+}
+
+export interface ExperimentConfig {
+  id: string;
+  name: string;
+  description: string;
+  enabled: boolean;
+  variants: ExperimentVariant[];
+}
+
+export interface ExperimentAssignment {
+  experimentId: string;
+  variantId: string;
+  assignedAt: string;
+  assignmentKey: string;
+}
+
+export interface VariantMetric {
+  experimentId: string;
+  variantId: string;
+  name: string;
+  value: number;
+  recordedAt: string;
+  properties?: EventProperties;
+}
+
+export interface SignificanceResult {
+  controlMean: number;
+  variantMean: number;
+  absoluteDifference: number;
+  relativeDifference: number;
+  pValue: number;
+  isSignificant: boolean;
+  confidenceLevel: number;
+}
+
+export interface ConversionSignificanceResult {
+  controlRate: number;
+  variantRate: number;
+  absoluteDifference: number;
+  relativeDifference: number;
+  pValue: number;
+  isSignificant: boolean;
+  confidenceLevel: number;
+}
+
+class ABTestingService {
+  private experiments = new Map<string, ExperimentConfig>();
+
+  public registerExperiment(config: ExperimentConfig): void {
+    this.validateExperiment(config);
+    this.experiments.set(config.id, config);
+  }
+
+  public registerExperiments(configs: ExperimentConfig[]): void {
+    configs.forEach(config => this.registerExperiment(config));
+  }
+
+  public getExperiment(experimentId: string): ExperimentConfig | undefined {
+    return this.experiments.get(experimentId);
+  }
+
+  public async getAssignment(
+    experimentId: string,
+    assignmentKey: string = 'anonymous',
+  ): Promise<ExperimentAssignment | null> {
+    const experiment = this.experiments.get(experimentId);
+    if (!experiment || !experiment.enabled) {
+      return null;
+    }
+
+    const storageKey = this.getStorageKey(experimentId, assignmentKey);
+    const existing = await this.getStoredAssignment(storageKey, experiment);
+    if (existing) {
+      return existing;
+    }
+
+    const assignment: ExperimentAssignment = {
+      experimentId,
+      variantId: this.pickVariant(experiment, assignmentKey),
+      assignedAt: new Date().toISOString(),
+      assignmentKey,
+    };
+
+    await AsyncStorage.setItem(storageKey, JSON.stringify(assignment));
+    mobileAnalyticsService.trackEvent(AnalyticsEvent.AB_ASSIGNMENT, {
+      ab_experiment_id: assignment.experimentId,
+      ab_variant_id: assignment.variantId,
+      ab_assignment_key: assignment.assignmentKey,
+    });
+
+    return assignment;
+  }
+
+  public async trackExposure(
+    experimentId: string,
+    assignmentKey: string = 'anonymous',
+    properties?: EventProperties,
+  ): Promise<ExperimentAssignment | null> {
+    const assignment = await this.getAssignment(experimentId, assignmentKey);
+    if (!assignment) {
+      return null;
+    }
+
+    mobileAnalyticsService.trackEvent(AnalyticsEvent.AB_EXPOSURE, {
+      ...properties,
+      ab_experiment_id: assignment.experimentId,
+      ab_variant_id: assignment.variantId,
+      ab_assignment_key: assignment.assignmentKey,
+    });
+
+    return assignment;
+  }
+
+  public async trackMetric(
+    experimentId: string,
+    name: string,
+    value: number,
+    assignmentKey: string = 'anonymous',
+    properties?: EventProperties,
+  ): Promise<VariantMetric | null> {
+    const assignment = await this.getAssignment(experimentId, assignmentKey);
+    if (!assignment) {
+      return null;
+    }
+
+    const metric: VariantMetric = {
+      experimentId,
+      variantId: assignment.variantId,
+      name,
+      value,
+      recordedAt: new Date().toISOString(),
+      properties,
+    };
+
+    mobileAnalyticsService.trackPerformance(name, value, {
+      ...properties,
+      ab_experiment_id: assignment.experimentId,
+      ab_variant_id: assignment.variantId,
+      ab_assignment_key: assignment.assignmentKey,
+    });
+
+    return metric;
+  }
+
+  public calculateMetricSignificance(
+    controlSamples: number[],
+    variantSamples: number[],
+    alpha: number = DEFAULT_ALPHA,
+  ): SignificanceResult {
+    if (controlSamples.length < 2 || variantSamples.length < 2) {
+      throw new Error('At least two samples are required for each variant.');
+    }
+
+    const controlMean = mean(controlSamples);
+    const variantMean = mean(variantSamples);
+    const controlVariance = sampleVariance(controlSamples, controlMean);
+    const variantVariance = sampleVariance(variantSamples, variantMean);
+    const standardError = Math.sqrt(
+      controlVariance / controlSamples.length + variantVariance / variantSamples.length,
+    );
+    const zScore = standardError === 0 ? 0 : (variantMean - controlMean) / standardError;
+    const pValue = twoTailedPValue(zScore);
+
+    return {
+      controlMean,
+      variantMean,
+      absoluteDifference: variantMean - controlMean,
+      relativeDifference: controlMean === 0 ? 0 : (variantMean - controlMean) / controlMean,
+      pValue,
+      isSignificant: pValue < alpha,
+      confidenceLevel: 1 - alpha,
+    };
+  }
+
+  public calculateConversionSignificance(
+    controlConversions: number,
+    controlTotal: number,
+    variantConversions: number,
+    variantTotal: number,
+    alpha: number = DEFAULT_ALPHA,
+  ): ConversionSignificanceResult {
+    if (controlTotal <= 0 || variantTotal <= 0) {
+      throw new Error('Conversion totals must be greater than zero.');
+    }
+
+    const controlRate = controlConversions / controlTotal;
+    const variantRate = variantConversions / variantTotal;
+    const pooledRate =
+      (controlConversions + variantConversions) / (controlTotal + variantTotal);
+    const standardError = Math.sqrt(
+      pooledRate * (1 - pooledRate) * (1 / controlTotal + 1 / variantTotal),
+    );
+    const zScore = standardError === 0 ? 0 : (variantRate - controlRate) / standardError;
+    const pValue = twoTailedPValue(zScore);
+
+    return {
+      controlRate,
+      variantRate,
+      absoluteDifference: variantRate - controlRate,
+      relativeDifference: controlRate === 0 ? 0 : (variantRate - controlRate) / controlRate,
+      pValue,
+      isSignificant: pValue < alpha,
+      confidenceLevel: 1 - alpha,
+    };
+  }
+
+  private async getStoredAssignment(
+    storageKey: string,
+    experiment: ExperimentConfig,
+  ): Promise<ExperimentAssignment | null> {
+    try {
+      const raw = await AsyncStorage.getItem(storageKey);
+      if (!raw) {
+        return null;
+      }
+
+      const assignment = JSON.parse(raw) as ExperimentAssignment;
+      const stillValid = experiment.variants.some(variant => variant.id === assignment.variantId);
+      return stillValid ? assignment : null;
+    } catch (error) {
+      logger.warn('ABTesting: Failed to read stored assignment', error);
+      return null;
+    }
+  }
+
+  private pickVariant(experiment: ExperimentConfig, assignmentKey: string): string {
+    const totalWeight = experiment.variants.reduce((sum, variant) => sum + variant.weight, 0);
+    const bucket = hashToUnitInterval(`${experiment.id}:${assignmentKey}`) * totalWeight;
+    let cumulative = 0;
+
+    for (const variant of experiment.variants) {
+      cumulative += variant.weight;
+      if (bucket < cumulative) {
+        return variant.id;
+      }
+    }
+
+    return experiment.variants[experiment.variants.length - 1].id;
+  }
+
+  private getStorageKey(experimentId: string, assignmentKey: string): string {
+    return `${ASSIGNMENT_STORAGE_PREFIX}:${experimentId}:${assignmentKey}`;
+  }
+
+  private validateExperiment(config: ExperimentConfig): void {
+    if (!config.id || !config.name || !config.description) {
+      throw new Error('Experiment id, name, and description are required.');
+    }
+
+    if (config.variants.length < 2) {
+      throw new Error('Experiments require at least two variants.');
+    }
+
+    const ids = new Set<string>();
+    config.variants.forEach(variant => {
+      if (!variant.id || !variant.name || variant.weight <= 0) {
+        throw new Error('Variant id, name, and positive weight are required.');
+      }
+
+      if (ids.has(variant.id)) {
+        throw new Error(`Duplicate variant id: ${variant.id}`);
+      }
+
+      ids.add(variant.id);
+    });
+  }
+}
+
+function mean(values: number[]): number {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function sampleVariance(values: number[], sampleMean: number): number {
+  const squaredDiffs = values.reduce((sum, value) => sum + (value - sampleMean) ** 2, 0);
+  return squaredDiffs / (values.length - 1);
+}
+
+function twoTailedPValue(zScore: number): number {
+  const probability = 0.5 * (1 + erf(Math.abs(zScore) / Math.SQRT2));
+  return 2 * (1 - probability);
+}
+
+function erf(value: number): number {
+  const sign = value >= 0 ? 1 : -1;
+  const x = Math.abs(value);
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const p = 0.3275911;
+  const t = 1 / (1 + p * x);
+  const y = 1 - (((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp(-x * x));
+
+  return sign * y;
+}
+
+function hashToUnitInterval(input: string): number {
+  let hash = 2166136261;
+
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return (hash >>> 0) / 4294967296;
+}
+
+export const abTestingService = new ABTestingService();
+export default abTestingService;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,1 +1,3 @@
+export * from './abTesting';
+export * from './performanceExperiments';
 export * from './pushNotifications';

--- a/src/services/performanceExperiments.ts
+++ b/src/services/performanceExperiments.ts
@@ -1,0 +1,63 @@
+import abTestingService, { ExperimentAssignment, ExperimentConfig } from './abTesting';
+
+export const IMAGE_PREFETCH_EXPERIMENT_ID = 'image_prefetch_delay_v1';
+
+export const performanceExperiments: ExperimentConfig[] = [
+  {
+    id: IMAGE_PREFETCH_EXPERIMENT_ID,
+    name: 'Image prefetch delay',
+    description:
+      'Compares immediate image prefetching with a short delay to reduce startup contention.',
+    enabled: true,
+    variants: [
+      {
+        id: 'control_immediate',
+        name: 'Immediate prefetch',
+        weight: 50,
+        description: 'Prefetch images as soon as the hook mounts.',
+      },
+      {
+        id: 'delayed_prefetch',
+        name: 'Delayed prefetch',
+        weight: 50,
+        description: 'Wait briefly before prefetching to leave startup work on the main path.',
+      },
+    ],
+  },
+];
+
+abTestingService.registerExperiments(performanceExperiments);
+
+export interface ImagePrefetchExperimentDecision {
+  assignment: ExperimentAssignment | null;
+  delayMs: number;
+}
+
+export async function getImagePrefetchExperimentDecision(
+  assignmentKey: string = 'anonymous',
+): Promise<ImagePrefetchExperimentDecision> {
+  const assignment = await abTestingService.trackExposure(
+    IMAGE_PREFETCH_EXPERIMENT_ID,
+    assignmentKey,
+    { optimization: 'image_prefetch_delay' },
+  );
+
+  return {
+    assignment,
+    delayMs: assignment?.variantId === 'delayed_prefetch' ? 250 : 0,
+  };
+}
+
+export async function trackImagePrefetchMetric(
+  durationMs: number,
+  assignmentKey: string = 'anonymous',
+  prefetchedCount: number = 0,
+): Promise<void> {
+  await abTestingService.trackMetric(
+    IMAGE_PREFETCH_EXPERIMENT_ID,
+    'image_prefetch_duration',
+    durationMs,
+    assignmentKey,
+    { prefetched_count: prefetchedCount },
+  );
+}

--- a/src/utils/trackingEvents.ts
+++ b/src/utils/trackingEvents.ts
@@ -36,6 +36,8 @@ export enum AnalyticsEvent {
 
   // Performance & Infrastructure
   PERFORMANCE_METRIC = 'performance_metric',
+  AB_ASSIGNMENT = 'ab_assignment',
+  AB_EXPOSURE = 'ab_exposure',
   API_ERROR = 'api_error',
   CRASH_REPORT = 'crash_report',
 }

--- a/tests/services/abTesting.test.ts
+++ b/tests/services/abTesting.test.ts
@@ -1,0 +1,162 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import abTestingService, { ExperimentConfig } from '../../src/services/abTesting';
+import mobileAnalyticsService from '../../src/services/mobileAnalytics';
+import {
+  getImagePrefetchExperimentDecision,
+  IMAGE_PREFETCH_EXPERIMENT_ID,
+  trackImagePrefetchMetric,
+} from '../../src/services/performanceExperiments';
+import { AnalyticsEvent } from '../../src/utils/trackingEvents';
+
+jest.mock('../../src/services/mobileAnalytics', () => ({
+  __esModule: true,
+  default: {
+    trackEvent: jest.fn(),
+    trackPerformance: jest.fn(),
+  },
+}));
+
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+const mockAnalytics = mobileAnalyticsService as jest.Mocked<typeof mobileAnalyticsService>;
+
+const experiment: ExperimentConfig = {
+  id: 'button_render_v1',
+  name: 'Button render path',
+  description: 'Compares two button render paths.',
+  enabled: true,
+  variants: [
+    { id: 'control', name: 'Control', weight: 50 },
+    { id: 'optimized', name: 'Optimized', weight: 50 },
+  ],
+};
+
+describe('abTestingService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAsyncStorage.getItem.mockResolvedValue(null);
+    abTestingService.registerExperiment(experiment);
+  });
+
+  it('assigns and persists a deterministic variant', async () => {
+    const first = await abTestingService.getAssignment(experiment.id, 'user-123');
+    const second = await abTestingService.getAssignment(experiment.id, 'user-123');
+
+    expect(first?.variantId).toBe(second?.variantId);
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
+      '@teachlink_ab_assignment:button_render_v1:user-123',
+      expect.stringContaining('"assignmentKey":"user-123"'),
+    );
+    expect(mockAnalytics.trackEvent).toHaveBeenCalledWith(
+      AnalyticsEvent.AB_ASSIGNMENT,
+      expect.objectContaining({
+        ab_experiment_id: experiment.id,
+        ab_assignment_key: 'user-123',
+      }),
+    );
+  });
+
+  it('reuses a stored assignment when the variant is still valid', async () => {
+    mockAsyncStorage.getItem.mockResolvedValueOnce(
+      JSON.stringify({
+        experimentId: experiment.id,
+        variantId: 'optimized',
+        assignedAt: '2026-05-28T00:00:00.000Z',
+        assignmentKey: 'user-456',
+      }),
+    );
+
+    const assignment = await abTestingService.getAssignment(experiment.id, 'user-456');
+
+    expect(assignment?.variantId).toBe('optimized');
+    expect(mockAsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('tracks exposures with experiment and variant metadata', async () => {
+    const assignment = await abTestingService.trackExposure(experiment.id, 'user-789', {
+      screen: 'home',
+    });
+
+    expect(assignment).not.toBeNull();
+    expect(mockAnalytics.trackEvent).toHaveBeenCalledWith(
+      AnalyticsEvent.AB_EXPOSURE,
+      expect.objectContaining({
+        screen: 'home',
+        ab_experiment_id: experiment.id,
+        ab_variant_id: assignment?.variantId,
+      }),
+    );
+  });
+
+  it('tracks performance metrics per assigned variant', async () => {
+    const metric = await abTestingService.trackMetric(
+      experiment.id,
+      'render_duration',
+      42,
+      'user-101',
+      { component: 'PrimaryButton' },
+    );
+
+    expect(metric).toEqual(
+      expect.objectContaining({
+        experimentId: experiment.id,
+        name: 'render_duration',
+        value: 42,
+      }),
+    );
+    expect(mockAnalytics.trackPerformance).toHaveBeenCalledWith(
+      'render_duration',
+      42,
+      expect.objectContaining({
+        component: 'PrimaryButton',
+        ab_experiment_id: experiment.id,
+        ab_variant_id: metric?.variantId,
+      }),
+    );
+  });
+
+  it('calculates statistical significance for numeric performance samples', () => {
+    const result = abTestingService.calculateMetricSignificance(
+      [100, 102, 98, 101, 99],
+      [80, 81, 79, 82, 78],
+    );
+
+    expect(result.variantMean).toBeLessThan(result.controlMean);
+    expect(result.pValue).toBeLessThan(0.05);
+    expect(result.isSignificant).toBe(true);
+  });
+
+  it('calculates conversion significance for proportion metrics', () => {
+    const result = abTestingService.calculateConversionSignificance(100, 1000, 140, 1000);
+
+    expect(result.variantRate).toBe(0.14);
+    expect(result.controlRate).toBe(0.1);
+    expect(result.isSignificant).toBe(true);
+  });
+
+  it('provides a concrete performance optimization experiment decision', async () => {
+    const decision = await getImagePrefetchExperimentDecision('user-202');
+
+    expect(decision.assignment?.experimentId).toBe(IMAGE_PREFETCH_EXPERIMENT_ID);
+    expect([0, 250]).toContain(decision.delayMs);
+    expect(mockAnalytics.trackEvent).toHaveBeenCalledWith(
+      AnalyticsEvent.AB_EXPOSURE,
+      expect.objectContaining({
+        optimization: 'image_prefetch_delay',
+        ab_experiment_id: IMAGE_PREFETCH_EXPERIMENT_ID,
+      }),
+    );
+  });
+
+  it('tracks the image prefetch performance experiment metric', async () => {
+    await trackImagePrefetchMetric(120, 'user-303', 6);
+
+    expect(mockAnalytics.trackPerformance).toHaveBeenCalledWith(
+      'image_prefetch_duration',
+      120,
+      expect.objectContaining({
+        prefetched_count: 6,
+        ab_experiment_id: IMAGE_PREFETCH_EXPERIMENT_ID,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes rinafcode/teachLink_mobile#382.

- Add a reusable A/B testing service with deterministic persisted variant assignment.
- Track experiment assignments, exposures, and performance metrics per variant through the existing analytics service.
- Add statistical significance helpers for numeric performance samples and conversion-rate experiments.
- Register an image prefetch delay experiment as the first performance optimization test.
- Document the A/B testing workflow and team training checklist.

## Validation

- `git diff --check` passed.
- Jest was not run locally because `npm` is not available on PATH and `node.exe` is blocked with `Access is denied` in this environment.
closes #382