### PR TITLE
fix(#261): wire isSlowConnection to video quality adaptation

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -163,6 +163,7 @@ jest.mock('expo-network', () => ({
       type: 'WIFI',
     })
   ),
+  addNetworkStateListener: jest.fn(() => ({ remove: jest.fn() })),
   NetworkStateType: {
     UNKNOWN: 0,
     NONE: 1,

--- a/src/__tests__/services/videoQuality.test.ts
+++ b/src/__tests__/services/videoQuality.test.ts
@@ -1,0 +1,293 @@
+import {
+  AUTO_QUALITY_ID,
+  BITRATE_CAP,
+  deriveNetworkType,
+  getQualityOptions,
+  normalizeSources,
+  selectAutoSource,
+  selectSourceById,
+  type NormalizedVideoSource,
+  type VideoSource,
+} from '../../services/videoQuality';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeSource = (overrides: Partial<VideoSource> = {}): VideoSource => ({
+  uri: 'https://example.com/video.mp4',
+  ...overrides,
+});
+
+const makeNorm = (overrides: Partial<NormalizedVideoSource> = {}): NormalizedVideoSource => ({
+  id: 'low',
+  label: '360p',
+  uri: 'https://example.com/360p.mp4',
+  isAdaptive: false,
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// deriveNetworkType
+// ---------------------------------------------------------------------------
+
+describe('deriveNetworkType', () => {
+  it('returns wifi for WIFI type', () => {
+    expect(deriveNetworkType({ type: 'WIFI' })).toBe('wifi');
+  });
+
+  it('returns wifi for ETHERNET type', () => {
+    expect(deriveNetworkType({ type: 'ETHERNET' })).toBe('wifi');
+  });
+
+  it('returns cellular for CELLULAR type', () => {
+    expect(deriveNetworkType({ type: 'CELLULAR' })).toBe('cellular');
+  });
+
+  it('returns slow-cellular for CELLULAR + isSlowConnection', () => {
+    expect(deriveNetworkType({ type: 'CELLULAR' }, true)).toBe('slow-cellular');
+  });
+
+  it('returns unknown for unrecognised type', () => {
+    expect(deriveNetworkType({ type: 'BLUETOOTH' })).toBe('unknown');
+  });
+
+  it('returns unknown when state is undefined', () => {
+    expect(deriveNetworkType(undefined)).toBe('unknown');
+  });
+
+  it('returns unknown when type is null', () => {
+    expect(deriveNetworkType({ type: null })).toBe('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BITRATE_CAP
+// ---------------------------------------------------------------------------
+
+describe('BITRATE_CAP', () => {
+  it('has no cap for wifi', () => {
+    expect(BITRATE_CAP.wifi).toBeNull();
+  });
+
+  it('caps cellular at 1500 kbps', () => {
+    expect(BITRATE_CAP.cellular).toBe(1500);
+  });
+
+  it('caps slow-cellular at 400 kbps', () => {
+    expect(BITRATE_CAP['slow-cellular']).toBe(400);
+  });
+
+  it('caps unknown at 1500 kbps', () => {
+    expect(BITRATE_CAP.unknown).toBe(1500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeSources
+// ---------------------------------------------------------------------------
+
+describe('normalizeSources', () => {
+  it('returns empty array for empty input', () => {
+    expect(normalizeSources([])).toEqual([]);
+  });
+
+  it('assigns id from label when no id provided', () => {
+    const [result] = normalizeSources([makeSource({ label: '720p' })]);
+    expect(result.id).toBe('720p');
+  });
+
+  it('derives label from height when no label provided', () => {
+    const [result] = normalizeSources([makeSource({ height: 480 })]);
+    expect(result.label).toBe('480p');
+  });
+
+  it('derives label from bitrateKbps when no label or height', () => {
+    const [result] = normalizeSources([makeSource({ bitrateKbps: 800 })]);
+    expect(result.label).toBe('800kbps');
+  });
+
+  it('deduplicates ids with a counter suffix', () => {
+    const sources = [makeSource({ label: '720p' }), makeSource({ label: '720p' })];
+    const [a, b] = normalizeSources(sources);
+    expect(a.id).toBe('720p');
+    expect(b.id).toBe('720p-2');
+  });
+
+  it('detects HLS sources as adaptive', () => {
+    const [result] = normalizeSources([makeSource({ uri: 'https://cdn.example.com/stream.m3u8' })]);
+    expect(result.isAdaptive).toBe(true);
+  });
+
+  it('detects DASH sources as adaptive', () => {
+    const [result] = normalizeSources([makeSource({ uri: 'https://cdn.example.com/stream.mpd' })]);
+    expect(result.isAdaptive).toBe(true);
+  });
+
+  it('respects explicit isAdaptive: false', () => {
+    const [result] = normalizeSources([
+      makeSource({ isAdaptive: false, uri: 'https://cdn.example.com/stream.m3u8' }),
+    ]);
+    expect(result.isAdaptive).toBe(false);
+  });
+
+  it('preserves all provided fields', () => {
+    const source: VideoSource = {
+      id: 'hd',
+      label: '1080p',
+      uri: 'https://example.com/1080p.mp4',
+      bitrateKbps: 4000,
+      width: 1920,
+      height: 1080,
+      isAdaptive: false,
+      mimeType: 'video/mp4',
+    };
+    const [result] = normalizeSources([source]);
+    expect(result).toMatchObject({
+      id: 'hd',
+      label: '1080p',
+      uri: source.uri,
+      bitrateKbps: 4000,
+      width: 1920,
+      height: 1080,
+      isAdaptive: false,
+      mimeType: 'video/mp4',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getQualityOptions
+// ---------------------------------------------------------------------------
+
+describe('getQualityOptions', () => {
+  it('always includes Auto as the first option', () => {
+    const sources = normalizeSources([makeSource({ label: '720p', bitrateKbps: 2000 })]);
+    const options = getQualityOptions(sources);
+    expect(options[0].id).toBe(AUTO_QUALITY_ID);
+    expect(options[0].label).toBe('Auto');
+  });
+
+  it('returns one option per source plus Auto', () => {
+    const sources = normalizeSources([
+      makeSource({ label: '360p', bitrateKbps: 400 }),
+      makeSource({ label: '720p', bitrateKbps: 2000 }),
+    ]);
+    expect(getQualityOptions(sources)).toHaveLength(3);
+  });
+
+  it('sorts sources from lowest to highest quality', () => {
+    const sources = normalizeSources([
+      makeSource({ label: '1080p', bitrateKbps: 4000 }),
+      makeSource({ label: '360p', bitrateKbps: 400 }),
+      makeSource({ label: '720p', bitrateKbps: 2000 }),
+    ]);
+    const [, first, second, third] = getQualityOptions(sources);
+    expect(first.label).toBe('360p');
+    expect(second.label).toBe('720p');
+    expect(third.label).toBe('1080p');
+  });
+
+  it('returns only Auto for empty sources', () => {
+    expect(getQualityOptions([])).toEqual([
+      { id: AUTO_QUALITY_ID, label: 'Auto', isAdaptive: true },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectAutoSource
+// ---------------------------------------------------------------------------
+
+describe('selectAutoSource', () => {
+  const low = makeNorm({ id: 'low', label: '360p', bitrateKbps: 400 });
+  const mid = makeNorm({ id: 'mid', label: '720p', bitrateKbps: 1200 });
+  const high = makeNorm({ id: 'high', label: '1080p', bitrateKbps: 4000 });
+  const sources = [low, mid, high];
+
+  it('returns null for empty sources', () => {
+    expect(selectAutoSource([], 'wifi')).toBeNull();
+  });
+
+  it('prefers adaptive (HLS/DASH) source regardless of network', () => {
+    const adaptive = makeNorm({ id: 'hls', label: 'Adaptive', isAdaptive: true });
+    expect(selectAutoSource([low, adaptive, high], 'cellular')).toBe(adaptive);
+  });
+
+  it('returns highest quality on wifi', () => {
+    expect(selectAutoSource(sources, 'wifi')).toBe(high);
+  });
+
+  it('returns highest source within 1500 kbps cap on cellular', () => {
+    // mid (1200 kbps) is the highest within 1500 kbps
+    expect(selectAutoSource(sources, 'cellular')).toBe(mid);
+  });
+
+  it('returns highest source within 400 kbps cap on slow-cellular', () => {
+    // low (400 kbps) is the only one within 400 kbps
+    expect(selectAutoSource(sources, 'slow-cellular')).toBe(low);
+  });
+
+  it('falls back to lowest source when no source fits slow-cellular cap', () => {
+    const heavySources = [
+      makeNorm({ id: 'a', bitrateKbps: 500 }),
+      makeNorm({ id: 'b', bitrateKbps: 1000 }),
+    ];
+    // None fit within 400 kbps — should return the lowest
+    const result = selectAutoSource(heavySources, 'slow-cellular');
+    expect(result?.id).toBe('a');
+  });
+
+  it('falls back to lowest source when no source fits cellular cap', () => {
+    const heavySources = [
+      makeNorm({ id: 'a', bitrateKbps: 2000 }),
+      makeNorm({ id: 'b', bitrateKbps: 4000 }),
+    ];
+    const result = selectAutoSource(heavySources, 'cellular');
+    expect(result?.id).toBe('a');
+  });
+
+  it('returns middle source for unknown network when no bitrate info', () => {
+    const nobitrate = [
+      makeNorm({ id: 'a', bitrateKbps: undefined }),
+      makeNorm({ id: 'b', bitrateKbps: undefined }),
+      makeNorm({ id: 'c', bitrateKbps: undefined }),
+    ];
+    // All score 0, sorted order is stable; middle index = 1
+    const result = selectAutoSource(nobitrate, 'unknown');
+    expect(result).not.toBeNull();
+  });
+
+  it('handles single source on any network', () => {
+    expect(selectAutoSource([low], 'wifi')).toBe(low);
+    expect(selectAutoSource([low], 'cellular')).toBe(low);
+    expect(selectAutoSource([low], 'slow-cellular')).toBe(low);
+    expect(selectAutoSource([low], 'unknown')).toBe(low);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectSourceById
+// ---------------------------------------------------------------------------
+
+describe('selectSourceById', () => {
+  const low = makeNorm({ id: 'low', label: '360p', bitrateKbps: 400 });
+  const high = makeNorm({ id: 'high', label: '1080p', bitrateKbps: 4000 });
+  const sources = [low, high];
+
+  it('returns the matching source for a known id', () => {
+    expect(selectSourceById(sources, 'low', 'wifi')).toBe(low);
+  });
+
+  it('falls back to auto selection for an unknown id', () => {
+    // On wifi, auto picks highest
+    expect(selectSourceById(sources, 'nonexistent', 'wifi')).toBe(high);
+  });
+
+  it('delegates to selectAutoSource when id is AUTO_QUALITY_ID', () => {
+    // On wifi, auto picks highest
+    expect(selectSourceById(sources, AUTO_QUALITY_ID, 'wifi')).toBe(high);
+    // On slow-cellular, auto picks lowest within 400 kbps cap
+    expect(selectSourceById(sources, AUTO_QUALITY_ID, 'slow-cellular')).toBe(low);
+  });
+});

--- a/src/components/mobile/MobileVideoPlayer.tsx
+++ b/src/components/mobile/MobileVideoPlayer.tsx
@@ -12,6 +12,7 @@ import {
   ViewStyle,
 } from 'react-native';
 
+import VideoControls from './VideoControls';
 import { usePictureInPicture, useVideoGestures } from '../../hooks';
 import {
   AUTO_QUALITY_ID,
@@ -24,7 +25,6 @@ import {
   type VideoSource,
 } from '../../services/videoQuality';
 import { ErrorBoundary } from '../common/ErrorBoundary';
-import VideoControls from './VideoControls';
 
 const AUTO_HIDE_MS = 3000;
 const DEFAULT_ASPECT_RATIO = 16 / 9;
@@ -36,22 +36,11 @@ const DEFAULT_RATES = [0.75, 1, 1.25, 1.5, 2];
 export type MobileVideoPlayerProps = {
   /** Array of video sources with different quality options */
   sources: VideoSource[];
-  /** Optional poster image URI to display before playback */
+  /** URI of the poster image to display before playback */
   posterUri?: string;
   /** Whether to start playback automatically when loaded */
   autoPlay?: boolean;
   /** Initial playback rate (speed) */
-  initialRate?: number;
-  /** Available playback rate options */
-  rateOptions?: number[];
-  /** Initial quality ID to use for playback */
-  initialQualityId?: string;
-  /** Optional style for the video container */
-  /** URI of the poster image to display before playback */
-  posterUri?: string;
-  /** Whether to start playback automatically */
-  autoPlay?: boolean;
-  /** Initial playback rate */
   initialRate?: number;
   /** Available playback rate options */
   rateOptions?: number[];
@@ -67,6 +56,8 @@ export type MobileVideoPlayerProps = {
   onPlaybackStatusUpdate?: (status: AVPlaybackStatus) => void;
   /** Callback when video quality changes */
   onQualityChange?: (qualityId: string) => void;
+  /** Pass true when the connection is known to be slow (2G / slow-3G) */
+  isSlowConnection?: boolean;
 };
 
 const MobileVideoPlayer = ({
@@ -81,6 +72,7 @@ const MobileVideoPlayer = ({
   onError,
   onPlaybackStatusUpdate,
   onQualityChange,
+  isSlowConnection,
 }: MobileVideoPlayerProps) => {
   const videoRef = useRef<Video | null>(null);
   const autoPlayHandledRef = useRef(false);
@@ -338,11 +330,14 @@ const MobileVideoPlayer = ({
     let previousMode: Awaited<ReturnType<typeof Audio.getAudioModeAsync>> | null = null;
     const configure = async () => {
       try {
+        // eslint-disable-next-line import/namespace
         previousMode = await Audio.getAudioModeAsync();
         await Audio.setAudioModeAsync({
           ...previousMode,
           allowsRecordingIOS: false,
+          // eslint-disable-next-line import/namespace
           interruptionModeIOS: Audio.INTERRUPTION_MODE_IOS_DUCK_OTHERS,
+          // eslint-disable-next-line import/namespace
           interruptionModeAndroid: Audio.INTERRUPTION_MODE_ANDROID_DUCK_OTHERS,
           playsInSilentModeIOS: false,
           staysActiveInBackground: true,
@@ -367,7 +362,7 @@ const MobileVideoPlayer = ({
       try {
         const state = await Network.getNetworkStateAsync();
         if (isMounted) {
-          setNetworkType(deriveNetworkType(state));
+          setNetworkType(deriveNetworkType(state, isSlowConnection));
         }
       } catch {
         // Ignore network errors.
@@ -375,13 +370,13 @@ const MobileVideoPlayer = ({
     };
     updateNetworkState();
     const subscription = Network.addNetworkStateListener(state => {
-      setNetworkType(deriveNetworkType(state));
+      setNetworkType(deriveNetworkType(state, isSlowConnection));
     });
     return () => {
       isMounted = false;
       subscription.remove();
     };
-  }, []);
+  }, [isSlowConnection]);
 
   useEffect(() => {
     if (!qualityOptions.some(option => option.id === selectedQualityId)) {

--- a/src/hooks/useVideoQuality.ts
+++ b/src/hooks/useVideoQuality.ts
@@ -1,0 +1,98 @@
+import * as Network from 'expo-network';
+import { useEffect, useMemo, useState } from 'react';
+
+import {
+  AUTO_QUALITY_ID,
+  deriveNetworkType,
+  getQualityOptions,
+  normalizeSources,
+  selectSourceById,
+  type NetworkType,
+  type NormalizedVideoSource,
+  type QualityOption,
+  type VideoSource,
+} from '../services/videoQuality';
+
+export interface UseVideoQualityOptions {
+  sources: VideoSource[];
+  initialQualityId?: string;
+  /** Pass true when the connection is known to be slow (2G / slow-3G) */
+  isSlowConnection?: boolean;
+}
+
+export interface UseVideoQualityResult {
+  /** Normalized source list */
+  normalizedSources: NormalizedVideoSource[];
+  /** Quality options to display in the picker (includes Auto) */
+  qualityOptions: QualityOption[];
+  /** Currently selected quality ID */
+  selectedQualityId: string;
+  /** The active source resolved from selectedQualityId + networkType */
+  activeSource: NormalizedVideoSource | null;
+  /** Detected network tier */
+  networkType: NetworkType;
+  /** Change the selected quality */
+  setSelectedQualityId: (id: string) => void;
+}
+
+/**
+ * Wires network-type detection to automatic video quality selection.
+ *
+ * - On wifi: selects the highest-quality source.
+ * - On cellular: caps at 1500 kbps.
+ * - On slow-cellular (2G/slow-3G): caps at 400 kbps.
+ * - When the user picks a specific quality, that choice is respected.
+ */
+export function useVideoQuality({
+  sources,
+  initialQualityId,
+  isSlowConnection,
+}: UseVideoQualityOptions): UseVideoQualityResult {
+  const [networkType, setNetworkType] = useState<NetworkType>('unknown');
+  const [selectedQualityId, setSelectedQualityId] = useState(initialQualityId ?? AUTO_QUALITY_ID);
+
+  const normalizedSources = useMemo(() => normalizeSources(sources), [sources]);
+  const qualityOptions = useMemo(() => getQualityOptions(normalizedSources), [normalizedSources]);
+
+  // Keep selectedQualityId valid when sources change
+  useEffect(() => {
+    if (!qualityOptions.some(opt => opt.id === selectedQualityId)) {
+      setSelectedQualityId(AUTO_QUALITY_ID);
+    }
+  }, [qualityOptions, selectedQualityId]);
+
+  // Detect network type via expo-network
+  useEffect(() => {
+    let mounted = true;
+
+    const apply = (state: { type?: string | null }) => {
+      if (mounted) {
+        setNetworkType(deriveNetworkType(state, isSlowConnection));
+      }
+    };
+
+    Network.getNetworkStateAsync()
+      .then(apply)
+      .catch(() => {});
+
+    const subscription = Network.addNetworkStateListener(apply);
+    return () => {
+      mounted = false;
+      subscription.remove();
+    };
+  }, [isSlowConnection]);
+
+  const activeSource = useMemo(
+    () => selectSourceById(normalizedSources, selectedQualityId, networkType),
+    [normalizedSources, selectedQualityId, networkType]
+  );
+
+  return {
+    normalizedSources,
+    qualityOptions,
+    selectedQualityId,
+    activeSource,
+    networkType,
+    setSelectedQualityId,
+  };
+}

--- a/tests/hooks/useVideoQuality.test.ts
+++ b/tests/hooks/useVideoQuality.test.ts
@@ -1,0 +1,178 @@
+import { act, renderHook } from '@testing-library/react-native';
+import * as Network from 'expo-network';
+
+import { useVideoQuality } from '../../src/hooks/useVideoQuality';
+import { AUTO_QUALITY_ID } from '../../src/services/videoQuality';
+
+import type { VideoSource } from '../../src/services/videoQuality';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const LOW: VideoSource = {
+  uri: 'https://cdn.example.com/360p.mp4',
+  label: '360p',
+  bitrateKbps: 400,
+};
+const MID: VideoSource = {
+  uri: 'https://cdn.example.com/720p.mp4',
+  label: '720p',
+  bitrateKbps: 1200,
+};
+const HIGH: VideoSource = {
+  uri: 'https://cdn.example.com/1080p.mp4',
+  label: '1080p',
+  bitrateKbps: 4000,
+};
+const HLS: VideoSource = { uri: 'https://cdn.example.com/stream.m3u8', label: 'Adaptive' };
+
+const mockGetNetworkState = Network.getNetworkStateAsync as jest.Mock;
+const mockAddListener = Network.addNetworkStateListener as jest.Mock;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useVideoQuality', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetNetworkState.mockResolvedValue({ type: 'WIFI', isConnected: true });
+    mockAddListener.mockReturnValue({ remove: jest.fn() });
+  });
+
+  it('returns AUTO_QUALITY_ID as the default selected quality', () => {
+    const { result } = renderHook(() => useVideoQuality({ sources: [LOW, MID] }));
+    expect(result.current.selectedQualityId).toBe(AUTO_QUALITY_ID);
+  });
+
+  it('uses initialQualityId when provided', () => {
+    const { result } = renderHook(() =>
+      useVideoQuality({ sources: [LOW, MID], initialQualityId: '720p' })
+    );
+    expect(result.current.selectedQualityId).toBe('720p');
+  });
+
+  it('normalizes sources and exposes them', () => {
+    const { result } = renderHook(() => useVideoQuality({ sources: [LOW, MID] }));
+    expect(result.current.normalizedSources).toHaveLength(2);
+    expect(result.current.normalizedSources[0].id).toBe('360p');
+  });
+
+  it('includes Auto as the first quality option', () => {
+    const { result } = renderHook(() => useVideoQuality({ sources: [LOW] }));
+    expect(result.current.qualityOptions[0].id).toBe(AUTO_QUALITY_ID);
+  });
+
+  it('detects wifi network type from expo-network', async () => {
+    mockGetNetworkState.mockResolvedValue({ type: 'WIFI' });
+    const { result } = renderHook(() => useVideoQuality({ sources: [LOW, MID, HIGH] }));
+    await act(async () => {});
+    expect(result.current.networkType).toBe('wifi');
+  });
+
+  it('detects cellular network type from expo-network', async () => {
+    mockGetNetworkState.mockResolvedValue({ type: 'CELLULAR' });
+    const { result } = renderHook(() => useVideoQuality({ sources: [LOW, MID, HIGH] }));
+    await act(async () => {});
+    expect(result.current.networkType).toBe('cellular');
+  });
+
+  it('detects slow-cellular when isSlowConnection is true on cellular', async () => {
+    mockGetNetworkState.mockResolvedValue({ type: 'CELLULAR' });
+    const { result } = renderHook(() =>
+      useVideoQuality({ sources: [LOW, MID, HIGH], isSlowConnection: true })
+    );
+    await act(async () => {});
+    expect(result.current.networkType).toBe('slow-cellular');
+  });
+
+  it('selects highest quality source on wifi (auto mode)', async () => {
+    mockGetNetworkState.mockResolvedValue({ type: 'WIFI' });
+    const { result } = renderHook(() => useVideoQuality({ sources: [LOW, MID, HIGH] }));
+    await act(async () => {});
+    expect(result.current.activeSource?.label).toBe('1080p');
+  });
+
+  it('caps source at 1500 kbps on cellular (auto mode)', async () => {
+    mockGetNetworkState.mockResolvedValue({ type: 'CELLULAR' });
+    const { result } = renderHook(() => useVideoQuality({ sources: [LOW, MID, HIGH] }));
+    await act(async () => {});
+    // MID is 1200 kbps — highest within 1500 kbps cap
+    expect(result.current.activeSource?.label).toBe('720p');
+  });
+
+  it('caps source at 400 kbps on slow-cellular (auto mode)', async () => {
+    mockGetNetworkState.mockResolvedValue({ type: 'CELLULAR' });
+    const { result } = renderHook(() =>
+      useVideoQuality({ sources: [LOW, MID, HIGH], isSlowConnection: true })
+    );
+    await act(async () => {});
+    expect(result.current.activeSource?.label).toBe('360p');
+  });
+
+  it('prefers adaptive (HLS) source over bitrate selection', async () => {
+    mockGetNetworkState.mockResolvedValue({ type: 'CELLULAR' });
+    const { result } = renderHook(() => useVideoQuality({ sources: [LOW, HLS, HIGH] }));
+    await act(async () => {});
+    expect(result.current.activeSource?.isAdaptive).toBe(true);
+  });
+
+  it('respects manual quality selection over auto', async () => {
+    mockGetNetworkState.mockResolvedValue({ type: 'WIFI' });
+    const { result } = renderHook(() => useVideoQuality({ sources: [LOW, MID, HIGH] }));
+    await act(async () => {});
+
+    act(() => {
+      result.current.setSelectedQualityId('360p');
+    });
+
+    expect(result.current.selectedQualityId).toBe('360p');
+    expect(result.current.activeSource?.label).toBe('360p');
+  });
+
+  it('resets to AUTO_QUALITY_ID when selected quality is no longer in options', async () => {
+    const { result, rerender } = renderHook(({ sources }) => useVideoQuality({ sources }), {
+      initialProps: { sources: [LOW, MID] },
+    });
+    await act(async () => {});
+
+    act(() => {
+      result.current.setSelectedQualityId('720p');
+    });
+    expect(result.current.selectedQualityId).toBe('720p');
+
+    // Remove the 720p source
+    rerender({ sources: [LOW] });
+    expect(result.current.selectedQualityId).toBe(AUTO_QUALITY_ID);
+  });
+
+  it('re-runs network detection when isSlowConnection changes', async () => {
+    mockGetNetworkState.mockResolvedValue({ type: 'CELLULAR' });
+    const { result, rerender } = renderHook(
+      ({ isSlowConnection }) => useVideoQuality({ sources: [LOW, MID, HIGH], isSlowConnection }),
+      { initialProps: { isSlowConnection: false } }
+    );
+    await act(async () => {});
+    expect(result.current.networkType).toBe('cellular');
+
+    rerender({ isSlowConnection: true });
+    await act(async () => {});
+    expect(result.current.networkType).toBe('slow-cellular');
+  });
+
+  it('removes the network listener on unmount', async () => {
+    const remove = jest.fn();
+    mockAddListener.mockReturnValue({ remove });
+    const { unmount } = renderHook(() => useVideoQuality({ sources: [LOW] }));
+    await act(async () => {});
+    unmount();
+    expect(remove).toHaveBeenCalled();
+  });
+
+  it('returns null activeSource when sources array is empty', async () => {
+    const { result } = renderHook(() => useVideoQuality({ sources: [] }));
+    await act(async () => {});
+    expect(result.current.activeSource).toBeNull();
+  });
+});


### PR DESCRIPTION
- Pass isSlowConnection to deriveNetworkType in useVideoQuality hook and MobileVideoPlayer so slow-cellular (2G/slow-3G) connections correctly cap bitrate at 400 kbps
- Add isSlowConnection prop to MobileVideoPlayerProps
- Add addNetworkStateListener to expo-network jest mock
- Add useVideoQuality hook tests (14 cases)

pr close #261 