### PR TITLE
feat(components): error boundary with automatic retry and exponential backoff

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -6,6 +6,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import 'react-native-reanimated';
 
 import '../global.css'; // NativeWind CSS
+import { RetryErrorBoundary } from '../components/ErrorBoundary/RetryErrorBoundary';
 import { AnalyticsProvider, ErrorBoundary, OfflineIndicatorProvider } from '../src/components';
 import { useAnalytics } from '../src/hooks';
 import { useDeepLink } from '../src/hooks/useDeepLink';
@@ -115,24 +116,26 @@ const RootLayout = () => {
 
   return (
     <ErrorBoundary boundaryName="RootLayout">
-      <AnalyticsProvider>
-        <ScreenTracker />
-        <ThemeSync />
-        <OfflineIndicatorProvider>
-          <GestureHandlerRootView style={{ flex: 1 }}>
-            <Stack>
-              <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-              <Stack.Screen name="course-viewer" options={{ headerShown: false }} />
-              <Stack.Screen name="profile/[userId]" options={{ headerShown: false }} />
-              <Stack.Screen name="search" options={{ headerShown: false }} />
-              <Stack.Screen name="settings" options={{ headerShown: false }} />
-              <Stack.Screen name="qr-scanner" options={{ headerShown: false }} />
-              <Stack.Screen name="quiz" options={{ headerShown: false }} />
-              <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
-            </Stack>
-          </GestureHandlerRootView>
-        </OfflineIndicatorProvider>
-      </AnalyticsProvider>
+      <RetryErrorBoundary>
+        <AnalyticsProvider>
+          <ScreenTracker />
+          <ThemeSync />
+          <OfflineIndicatorProvider>
+            <GestureHandlerRootView style={{ flex: 1 }}>
+              <Stack>
+                <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+                <Stack.Screen name="course-viewer" options={{ headerShown: false }} />
+                <Stack.Screen name="profile/[userId]" options={{ headerShown: false }} />
+                <Stack.Screen name="search" options={{ headerShown: false }} />
+                <Stack.Screen name="settings" options={{ headerShown: false }} />
+                <Stack.Screen name="qr-scanner" options={{ headerShown: false }} />
+                <Stack.Screen name="quiz" options={{ headerShown: false }} />
+                <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
+              </Stack>
+            </GestureHandlerRootView>
+          </OfflineIndicatorProvider>
+        </AnalyticsProvider>
+      </RetryErrorBoundary>
     </ErrorBoundary>
   );
 };

--- a/components/ErrorBoundary/DefaultErrorFallback.tsx
+++ b/components/ErrorBoundary/DefaultErrorFallback.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
+
+/**
+ * Props for {@link DefaultErrorFallback}.
+ */
+export interface DefaultErrorFallbackProps {
+  /** The error that caused the boundary to give up after exhausting its retries. */
+  error: Error;
+  /** Resets the boundary and re-renders the child tree. Wired to the "Try Again" button. */
+  onRetry: () => void;
+}
+
+/**
+ * Generic fallback UI rendered by {@link RetryErrorBoundary} once automatic retries
+ * are exhausted. It deliberately avoids leaking raw error details to end users in
+ * production; the underlying message is only surfaced in development (`__DEV__`).
+ */
+export const DefaultErrorFallback: React.FC<DefaultErrorFallbackProps> = ({ error, onRetry }) => {
+  return (
+    <View className="flex-1 items-center justify-center bg-white p-6 dark:bg-slate-900">
+      <View className="w-full max-w-md rounded-2xl border border-slate-200 bg-white p-6 dark:border-slate-700 dark:bg-slate-800">
+        <Text className="mb-2 text-xl font-bold text-red-600 dark:text-red-400">
+          Something went wrong
+        </Text>
+        <Text className="mb-4 text-base text-slate-600 dark:text-slate-300">
+          We could not display this section. Please try again.
+        </Text>
+
+        {__DEV__ ? (
+          <ScrollView className="mb-4 max-h-40 rounded-lg bg-slate-100 p-3 dark:bg-slate-950">
+            <Text className="font-mono text-xs text-red-700 dark:text-red-300">
+              {error.message}
+            </Text>
+          </ScrollView>
+        ) : null}
+
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessibilityLabel="Try again"
+          className="items-center rounded-lg bg-sky-500 py-3"
+          onPress={onRetry}
+        >
+          <Text className="text-base font-semibold text-white">Try Again</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+};
+
+export default DefaultErrorFallback;

--- a/components/ErrorBoundary/RetryErrorBoundary.tsx
+++ b/components/ErrorBoundary/RetryErrorBoundary.tsx
@@ -1,0 +1,219 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+
+import { DefaultErrorFallback } from './DefaultErrorFallback';
+import { appLogger } from '../../src/utils/logger';
+
+/**
+ * Props for {@link RetryErrorBoundary}.
+ */
+export interface RetryErrorBoundaryProps {
+  /** Child tree guarded by the boundary. */
+  children: ReactNode;
+  /** Maximum number of automatic retries before the fallback UI is shown. Default: 3. */
+  maxRetries?: number;
+  /** Delay (ms) before the first retry; subsequent retries grow exponentially. Default: 500. */
+  baseDelayMs?: number;
+  /** Called every time an error is caught, with the current retry count. */
+  onError?: (error: Error, errorInfo: ErrorInfo, retryCount: number) => void;
+  /** Called when a retry re-renders the child tree successfully. */
+  onRetrySuccess?: (retryCount: number) => void;
+  /** Called when retries are exhausted or the error is classified as non-transient. */
+  onMaxRetriesReached?: (error: Error) => void;
+  /** Fallback UI. A React node, or a render function receiving the error and a manual retry handler. */
+  fallback?: ReactNode | ((error: Error, retry: () => void) => ReactNode);
+  /**
+   * Classifies an error as transient (retryable). When omitted, every error is treated
+   * as transient. Returning `false` skips retries and shows the fallback immediately.
+   */
+  isTransient?: (error: Error) => boolean;
+}
+
+/**
+ * Internal state for {@link RetryErrorBoundary}.
+ */
+export interface ErrorBoundaryState {
+  /** Whether an error is currently caught and awaiting retry or fallback. */
+  hasError: boolean;
+  /** The most recently caught error. */
+  error: Error | null;
+  /** Number of retries already attempted for the current failure streak. */
+  retryCount: number;
+  /** Whether a retry has been scheduled and is pending. */
+  isRetrying: boolean;
+  /** Total successful retries since mount (exposed for metrics). */
+  retrySuccessCount: number;
+  /** Total failed/abandoned retries since mount (exposed for metrics). */
+  retryFailureCount: number;
+}
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_BASE_DELAY_MS = 500;
+const MAX_BACKOFF_MS = 10_000;
+
+/**
+ * Error boundary that automatically retries transient render errors with exponential
+ * backoff before surfacing a fallback UI.
+ *
+ * React error boundaries only catch errors thrown during render, in lifecycle methods,
+ * and in child constructors — NOT in event handlers, async callbacks, or SSR. "Retrying"
+ * here means: after an error is caught, the boundary clears its error state after a
+ * backoff delay and re-renders the child tree. A clean render counts as a successful
+ * retry; another throw increments the retry count.
+ *
+ * Backoff schedule (with defaults): 500ms → 1000ms → 2000ms, capped at 10000ms.
+ */
+export class RetryErrorBoundary extends Component<RetryErrorBoundaryProps, ErrorBoundaryState> {
+  private retryTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(props: RetryErrorBoundaryProps) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: null,
+      retryCount: 0,
+      isRetrying: false,
+      retrySuccessCount: 0,
+      retryFailureCount: 0,
+    };
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return {
+      hasError: true,
+      error,
+      isRetrying: false,
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    const maxRetries = this.props.maxRetries ?? DEFAULT_MAX_RETRIES;
+
+    appLogger.errorSync('Error boundary caught error', error, {
+      error: error.message,
+      retryCount: this.state.retryCount,
+      stack: error.stack,
+    });
+
+    if (this.state.retryCount < maxRetries) {
+      if (this.isTransient(error)) {
+        this.setState({ isRetrying: true });
+        this.scheduleRetry();
+      } else {
+        appLogger.warnSync('Error boundary skipping retry for non-transient error', {
+          error: error.message,
+          retryCount: this.state.retryCount,
+        });
+        this.setState(prev => ({ retryFailureCount: prev.retryFailureCount + 1 }));
+        this.props.onMaxRetriesReached?.(error);
+      }
+      this.props.onError?.(error, errorInfo, this.state.retryCount);
+    } else {
+      appLogger.warnSync('Max retries reached for error boundary', {
+        error: error.message,
+        retryCount: this.state.retryCount,
+      });
+      this.setState(prev => ({ retryFailureCount: prev.retryFailureCount + 1 }));
+      this.props.onMaxRetriesReached?.(error);
+      this.props.onError?.(error, errorInfo, this.state.retryCount);
+    }
+  }
+
+  componentDidUpdate(_prevProps: RetryErrorBoundaryProps, prevState: ErrorBoundaryState): void {
+    // A retry succeeded when the error state clears after at least one retry attempt and
+    // the child re-renders without throwing again (otherwise `hasError` would be true).
+    if (prevState.hasError && !this.state.hasError && this.state.retryCount > 0) {
+      this.setState(prev => ({ retrySuccessCount: prev.retrySuccessCount + 1 }));
+      appLogger.infoSync('Error boundary retry succeeded', {
+        retryCount: this.state.retryCount,
+      });
+      this.props.onRetrySuccess?.(this.state.retryCount);
+    }
+  }
+
+  componentWillUnmount(): void {
+    if (this.retryTimeout) {
+      clearTimeout(this.retryTimeout);
+      this.retryTimeout = null;
+    }
+  }
+
+  private isTransient(error: Error): boolean {
+    return this.props.isTransient ? this.props.isTransient(error) : true;
+  }
+
+  private scheduleRetry(): void {
+    const baseDelayMs = this.props.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+    const delay = Math.min(baseDelayMs * Math.pow(2, this.state.retryCount), MAX_BACKOFF_MS);
+
+    appLogger.infoSync('Error boundary scheduling retry', {
+      retryCount: this.state.retryCount,
+      delayMs: delay,
+    });
+
+    this.retryTimeout = setTimeout(() => {
+      this.retryTimeout = null;
+      this.setState(prev => ({
+        hasError: false,
+        error: null,
+        isRetrying: false,
+        retryCount: prev.retryCount + 1,
+      }));
+    }, delay);
+  }
+
+  private handleManualRetry = (): void => {
+    if (this.retryTimeout) {
+      clearTimeout(this.retryTimeout);
+      this.retryTimeout = null;
+    }
+    this.setState({
+      hasError: false,
+      error: null,
+      retryCount: 0,
+      isRetrying: false,
+    });
+  };
+
+  private renderFallback(error: Error): ReactNode {
+    const { fallback } = this.props;
+    if (typeof fallback === 'function') {
+      return fallback(error, this.handleManualRetry);
+    }
+    return fallback ?? <DefaultErrorFallback error={error} onRetry={this.handleManualRetry} />;
+  }
+
+  render(): ReactNode {
+    const maxRetries = this.props.maxRetries ?? DEFAULT_MAX_RETRIES;
+
+    if (this.state.hasError && this.state.error) {
+      const exhausted = this.state.retryCount >= maxRetries || !this.isTransient(this.state.error);
+
+      if (exhausted) {
+        return this.renderFallback(this.state.error);
+      }
+
+      // A retry is pending. Re-rendering `children` now would immediately throw again and
+      // spin React's error path synchronously, so show a subtle indicator until the
+      // scheduled retry clears the error state.
+      return (
+        <View style={styles.retryContainer} accessibilityLabel="Retrying">
+          <ActivityIndicator />
+        </View>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+const styles = StyleSheet.create({
+  retryContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+});
+
+export default RetryErrorBoundary;

--- a/docs/error-boundary-retry-strategy.md
+++ b/docs/error-boundary-retry-strategy.md
@@ -1,0 +1,129 @@
+# Error Boundary Retry Strategy
+
+## Overview
+
+`RetryErrorBoundary` is a React class error boundary that automatically recovers from
+**transient render errors** before ever showing an error screen to the user. When a child
+component throws during render, the boundary catches the error, waits for a short backoff
+delay, and then re-renders the child tree. Many failures — a momentary missing value, a
+race during data hydration, a transient native-module hiccup — succeed on the second or
+third attempt. By retrying silently (with a subtle loading indicator) instead of
+immediately rendering a "Something went wrong" screen, the app feels noticeably more
+resilient. Only after the configured number of retries is exhausted (or when an error is
+explicitly classified as non-transient) does the fallback UI appear.
+
+## Retry strategy
+
+Retries use exponential backoff: `delay = baseDelayMs * 2 ^ retryCount`, capped at
+10,000 ms. With the default `baseDelayMs` of 500 ms and `maxRetries` of 3:
+
+| Attempt                             | Delay before retry |
+| ----------------------------------- | ------------------ |
+| 1st                                 | 500ms              |
+| 2nd                                 | 1000ms             |
+| 3rd                                 | 2000ms             |
+| Fallback UI shown after 3rd failure |
+
+Every retry is logged through the centralised `appLogger`:
+
+- `appLogger.errorSync('Error boundary caught error', …)` — each caught error.
+- `appLogger.infoSync('Error boundary scheduling retry', { retryCount, delayMs })` — before each retry.
+- `appLogger.infoSync('Error boundary retry succeeded', { retryCount })` — when a retry recovers.
+- `appLogger.warnSync('Max retries reached for error boundary', …)` — when retries are exhausted.
+
+## Props reference
+
+| Prop                  | Type                                                     | Default                    | Description                                                                                           |
+| --------------------- | -------------------------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `children`            | `React.ReactNode`                                        | —                          | The child tree guarded by the boundary.                                                               |
+| `maxRetries`          | `number`                                                 | `3`                        | Maximum automatic retries before the fallback UI is shown.                                            |
+| `baseDelayMs`         | `number`                                                 | `500`                      | Delay (ms) before the first retry; doubles each subsequent attempt.                                   |
+| `onError`             | `(error, errorInfo, retryCount) => void`                 | —                          | Called on every caught error, with the current retry count.                                           |
+| `onRetrySuccess`      | `(retryCount) => void`                                   | —                          | Called when a retry re-renders the children successfully.                                             |
+| `onMaxRetriesReached` | `(error) => void`                                        | —                          | Called when retries are exhausted or the error is non-transient.                                      |
+| `fallback`            | `React.ReactNode \| ((error, retry) => React.ReactNode)` | `<DefaultErrorFallback />` | Fallback UI. A node, or a render function receiving the error and a manual retry handler.             |
+| `isTransient`         | `(error) => boolean`                                     | retries everything         | Classifies an error as retryable. Returning `false` skips retries and shows the fallback immediately. |
+
+## Usage examples
+
+### 1. Basic usage (defaults)
+
+```tsx
+// from app/_layout.tsx the boundary lives in the top-level components/ directory
+import { RetryErrorBoundary } from '../components/ErrorBoundary/RetryErrorBoundary';
+
+<RetryErrorBoundary>
+  <MyScreen />
+</RetryErrorBoundary>;
+```
+
+### 2. Custom fallback render function
+
+```tsx
+<RetryErrorBoundary
+  maxRetries={5}
+  baseDelayMs={250}
+  fallback={(error, retry) => (
+    <View>
+      <Text>We couldn't load this screen.</Text>
+      <Button title="Retry" onPress={retry} />
+    </View>
+  )}
+>
+  <MyScreen />
+</RetryErrorBoundary>
+```
+
+### 3. With metrics tracking via `useErrorBoundaryMetrics`
+
+```tsx
+import { useErrorBoundaryMetrics } from '../hooks/useErrorBoundaryMetrics';
+
+function GuardedScreen({ children }: { children: React.ReactNode }) {
+  const { metrics, recordError, recordRetrySuccess, recordRetryFailure } =
+    useErrorBoundaryMetrics();
+
+  return (
+    <RetryErrorBoundary
+      onError={() => recordError()}
+      onRetrySuccess={() => recordRetrySuccess()}
+      onMaxRetriesReached={() => recordRetryFailure()}
+    >
+      {children}
+    </RetryErrorBoundary>
+  );
+}
+```
+
+`metrics.successRate` is derived as `successfulRetries / totalRetries` (0 when there have
+been no retries) and can be surfaced on a diagnostics screen or forwarded to analytics.
+
+## When NOT to use
+
+React error boundaries only catch errors thrown during **render**, in **lifecycle
+methods**, and in **child constructors**. They do not help with:
+
+- **Event handler errors** (e.g. `onPress`) — wrap those in `try/catch`.
+- **Asynchronous errors** (promises, `setTimeout`, `fetch` callbacks) — handle them where
+  the async work happens; they never reach the boundary.
+- **Server-side rendering** — boundaries don't catch SSR errors.
+- **Non-transient errors** — a genuinely broken component will fail every retry. Use
+  `isTransient` to skip pointless retries and fail fast (see below).
+
+## Classifying transient errors
+
+By default every caught error is treated as transient and retried. Pass an `isTransient`
+predicate to retry only the errors that are actually worth retrying — typically network or
+timeout errors — and to show the fallback immediately for everything else:
+
+```tsx
+const isNetworkError = (error: Error): boolean =>
+  /network|timeout|connection|fetch/i.test(error.message);
+
+<RetryErrorBoundary isTransient={isNetworkError}>
+  <CourseList />
+</RetryErrorBoundary>;
+```
+
+When `isTransient` returns `false`, the boundary skips the backoff/retry cycle entirely,
+calls `onMaxRetriesReached`, and renders the fallback UI on the first failure.

--- a/hooks/useErrorBoundaryMetrics.ts
+++ b/hooks/useErrorBoundaryMetrics.ts
@@ -1,0 +1,92 @@
+import { useCallback, useMemo, useState } from 'react';
+
+/**
+ * Aggregated retry metrics exposed by {@link useErrorBoundaryMetrics}.
+ */
+export interface ErrorBoundaryMetrics {
+  /** Total errors caught (each catch, including those that later succeed on retry). */
+  totalErrors: number;
+  /** Total retries that have resolved one way or another (successes + failures). */
+  totalRetries: number;
+  /** Retries that recovered the child tree. */
+  successfulRetries: number;
+  /** Retries that were abandoned (exhausted or non-transient). */
+  failedRetries: number;
+  /** `successfulRetries / totalRetries`, or 0 when no retries have resolved. */
+  successRate: number;
+}
+
+/**
+ * Return shape of {@link useErrorBoundaryMetrics}.
+ */
+export interface UseErrorBoundaryMetricsResult {
+  metrics: ErrorBoundaryMetrics;
+  recordError: () => void;
+  recordRetrySuccess: () => void;
+  recordRetryFailure: () => void;
+  resetMetrics: () => void;
+}
+
+interface MetricsCounters {
+  totalErrors: number;
+  totalRetries: number;
+  successfulRetries: number;
+  failedRetries: number;
+}
+
+const INITIAL_COUNTERS: MetricsCounters = {
+  totalErrors: 0,
+  totalRetries: 0,
+  successfulRetries: 0,
+  failedRetries: 0,
+};
+
+/**
+ * In-memory store for error-boundary retry metrics, scoped to the React tree that
+ * mounts it. Wire the returned callbacks into a {@link RetryErrorBoundary}'s
+ * `onError` / `onRetrySuccess` / `onMaxRetriesReached` props to record events.
+ *
+ * Counters live in React state (not module-level mutable variables) so each consumer
+ * gets its own isolated tally. `successRate` is derived, never stored.
+ */
+export function useErrorBoundaryMetrics(): UseErrorBoundaryMetricsResult {
+  const [counters, setCounters] = useState<MetricsCounters>(INITIAL_COUNTERS);
+
+  const recordError = useCallback(() => {
+    setCounters(prev => ({ ...prev, totalErrors: prev.totalErrors + 1 }));
+  }, []);
+
+  const recordRetrySuccess = useCallback(() => {
+    setCounters(prev => ({
+      ...prev,
+      successfulRetries: prev.successfulRetries + 1,
+      totalRetries: prev.totalRetries + 1,
+    }));
+  }, []);
+
+  const recordRetryFailure = useCallback(() => {
+    setCounters(prev => ({
+      ...prev,
+      failedRetries: prev.failedRetries + 1,
+      totalRetries: prev.totalRetries + 1,
+    }));
+  }, []);
+
+  const resetMetrics = useCallback(() => {
+    setCounters(INITIAL_COUNTERS);
+  }, []);
+
+  const successRate = useMemo(
+    () => (counters.totalRetries === 0 ? 0 : counters.successfulRetries / counters.totalRetries),
+    [counters.totalRetries, counters.successfulRetries]
+  );
+
+  const metrics = useMemo<ErrorBoundaryMetrics>(
+    () => ({ ...counters, successRate }),
+    [counters, successRate]
+  );
+
+  return { metrics, recordError, recordRetrySuccess, recordRetryFailure, resetMetrics };
+}
+
+export default useErrorBoundaryMetrics;

--- a/tests/components/RetryErrorBoundary.test.tsx
+++ b/tests/components/RetryErrorBoundary.test.tsx
@@ -1,0 +1,217 @@
+import { act, fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { Text } from 'react-native';
+
+import { RetryErrorBoundary } from '../../components/ErrorBoundary/RetryErrorBoundary';
+import { appLogger } from '../../src/utils/logger';
+
+// Mock the centralised logger so retry events can be asserted and no async
+// persistence / remote logging runs during tests. `jest.mock` is hoisted above the
+// imports above, so the boundary picks up this mocked logger.
+jest.mock('../../src/utils/logger', () => ({
+  appLogger: {
+    errorSync: jest.fn(),
+    warnSync: jest.fn(),
+    infoSync: jest.fn(),
+  },
+}));
+
+const infoSync = appLogger.infoSync as jest.Mock;
+
+/**
+ * A child whose throwing behaviour is controlled by an external mutable object so the
+ * test can flip it between `act` steps. This is deterministic regardless of how many
+ * times React invokes the render of a throwing component.
+ */
+interface ThrowControl {
+  shouldThrow: boolean;
+  message?: string;
+}
+
+const Flaky = ({ control }: { control: ThrowControl }): React.ReactElement => {
+  if (control.shouldThrow) {
+    throw new Error(control.message ?? 'transient failure');
+  }
+  return <Text>recovered</Text>;
+};
+
+const scheduleDelays = (): number[] =>
+  infoSync.mock.calls
+    .filter(call => call[0] === 'Error boundary scheduling retry')
+    .map(call => call[1].delayMs as number);
+
+describe('RetryErrorBoundary', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // React logs caught render errors via console.error — silence the noise.
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('renders children normally when no error is thrown', () => {
+    const { getByText, queryByText } = render(
+      <RetryErrorBoundary>
+        <Text>hello world</Text>
+      </RetryErrorBoundary>
+    );
+
+    expect(getByText('hello world')).toBeTruthy();
+    expect(queryByText('Something went wrong')).toBeNull();
+  });
+
+  it('retries automatically and renders children once the error clears', () => {
+    const control: ThrowControl = { shouldThrow: true };
+
+    const { getByLabelText, queryByText } = render(
+      <RetryErrorBoundary baseDelayMs={500}>
+        <Flaky control={control} />
+      </RetryErrorBoundary>
+    );
+
+    // While the retry is pending, the spinner is shown instead of children.
+    expect(getByLabelText('Retrying')).toBeTruthy();
+    expect(queryByText('recovered')).toBeNull();
+
+    control.shouldThrow = false;
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(queryByText('recovered')).toBeTruthy();
+  });
+
+  it('shows the fallback UI after the max number of retries (3) is exhausted', () => {
+    const control: ThrowControl = { shouldThrow: true };
+
+    const { getByText } = render(
+      <RetryErrorBoundary baseDelayMs={500} maxRetries={3}>
+        <Flaky control={control} />
+      </RetryErrorBoundary>
+    );
+
+    act(() => jest.advanceTimersByTime(500));
+    act(() => jest.advanceTimersByTime(1000));
+    act(() => jest.advanceTimersByTime(2000));
+
+    expect(getByText('Something went wrong')).toBeTruthy();
+    expect(getByText('Try Again')).toBeTruthy();
+  });
+
+  it('uses exponential backoff delays of 500ms, 1000ms, then 2000ms', () => {
+    const control: ThrowControl = { shouldThrow: true };
+
+    render(
+      <RetryErrorBoundary baseDelayMs={500} maxRetries={3}>
+        <Flaky control={control} />
+      </RetryErrorBoundary>
+    );
+
+    act(() => jest.advanceTimersByTime(500));
+    act(() => jest.advanceTimersByTime(1000));
+    act(() => jest.advanceTimersByTime(2000));
+
+    expect(scheduleDelays()).toEqual([500, 1000, 2000]);
+  });
+
+  it('calls onRetrySuccess with the retry count when a retry succeeds', () => {
+    const control: ThrowControl = { shouldThrow: true };
+    const onRetrySuccess = jest.fn();
+
+    render(
+      <RetryErrorBoundary baseDelayMs={500} onRetrySuccess={onRetrySuccess}>
+        <Flaky control={control} />
+      </RetryErrorBoundary>
+    );
+
+    control.shouldThrow = false;
+    act(() => jest.advanceTimersByTime(500));
+
+    expect(onRetrySuccess).toHaveBeenCalledTimes(1);
+    expect(onRetrySuccess).toHaveBeenCalledWith(1);
+  });
+
+  it('calls onMaxRetriesReached when retries are exhausted', () => {
+    const control: ThrowControl = { shouldThrow: true, message: 'permanent boom' };
+    const onMaxRetriesReached = jest.fn();
+
+    render(
+      <RetryErrorBoundary
+        baseDelayMs={500}
+        maxRetries={3}
+        onMaxRetriesReached={onMaxRetriesReached}
+      >
+        <Flaky control={control} />
+      </RetryErrorBoundary>
+    );
+
+    act(() => jest.advanceTimersByTime(500));
+    act(() => jest.advanceTimersByTime(1000));
+    act(() => jest.advanceTimersByTime(2000));
+
+    expect(onMaxRetriesReached).toHaveBeenCalledTimes(1);
+    expect(onMaxRetriesReached.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(onMaxRetriesReached.mock.calls[0][0].message).toBe('permanent boom');
+  });
+
+  it('skips retries and shows the fallback immediately when isTransient returns false', () => {
+    const control: ThrowControl = { shouldThrow: true };
+    const onMaxRetriesReached = jest.fn();
+
+    const { getByText } = render(
+      <RetryErrorBoundary isTransient={() => false} onMaxRetriesReached={onMaxRetriesReached}>
+        <Flaky control={control} />
+      </RetryErrorBoundary>
+    );
+
+    expect(getByText('Something went wrong')).toBeTruthy();
+    expect(scheduleDelays()).toEqual([]);
+    expect(onMaxRetriesReached).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets the retry count to 0 when the manual "Try Again" button is pressed', () => {
+    const control: ThrowControl = { shouldThrow: true };
+    const ref = React.createRef<RetryErrorBoundary>();
+
+    const { getByLabelText } = render(
+      <RetryErrorBoundary ref={ref} baseDelayMs={500} maxRetries={3}>
+        <Flaky control={control} />
+      </RetryErrorBoundary>
+    );
+
+    act(() => jest.advanceTimersByTime(500));
+    act(() => jest.advanceTimersByTime(1000));
+    act(() => jest.advanceTimersByTime(2000));
+
+    expect(ref.current?.state.retryCount).toBe(3);
+
+    act(() => {
+      fireEvent.press(getByLabelText('Try again'));
+    });
+
+    expect(ref.current?.state.retryCount).toBe(0);
+  });
+
+  it('clears any pending retry timeout when unmounted', () => {
+    const control: ThrowControl = { shouldThrow: true };
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+    const { unmount } = render(
+      <RetryErrorBoundary baseDelayMs={500}>
+        <Flaky control={control} />
+      </RetryErrorBoundary>
+    );
+
+    // A retry is scheduled (pending timeout) right after the first failure.
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+});

--- a/tests/hooks/useErrorBoundaryMetrics.test.ts
+++ b/tests/hooks/useErrorBoundaryMetrics.test.ts
@@ -1,0 +1,81 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useErrorBoundaryMetrics } from '../../hooks/useErrorBoundaryMetrics';
+
+describe('useErrorBoundaryMetrics', () => {
+  it('starts with all counts at zero and a success rate of 0', () => {
+    const { result } = renderHook(() => useErrorBoundaryMetrics());
+
+    expect(result.current.metrics).toEqual({
+      totalErrors: 0,
+      totalRetries: 0,
+      successfulRetries: 0,
+      failedRetries: 0,
+      successRate: 0,
+    });
+  });
+
+  it('recordError increments totalErrors only', () => {
+    const { result } = renderHook(() => useErrorBoundaryMetrics());
+
+    act(() => result.current.recordError());
+    act(() => result.current.recordError());
+
+    expect(result.current.metrics.totalErrors).toBe(2);
+    expect(result.current.metrics.totalRetries).toBe(0);
+  });
+
+  it('recordRetrySuccess increments successfulRetries and totalRetries and updates successRate', () => {
+    const { result } = renderHook(() => useErrorBoundaryMetrics());
+
+    act(() => result.current.recordRetrySuccess());
+
+    expect(result.current.metrics.successfulRetries).toBe(1);
+    expect(result.current.metrics.totalRetries).toBe(1);
+    expect(result.current.metrics.successRate).toBe(1);
+  });
+
+  it('recordRetryFailure increments failedRetries and totalRetries', () => {
+    const { result } = renderHook(() => useErrorBoundaryMetrics());
+
+    act(() => result.current.recordRetryFailure());
+
+    expect(result.current.metrics.failedRetries).toBe(1);
+    expect(result.current.metrics.totalRetries).toBe(1);
+    expect(result.current.metrics.successRate).toBe(0);
+  });
+
+  it('resetMetrics returns all counts to zero', () => {
+    const { result } = renderHook(() => useErrorBoundaryMetrics());
+
+    act(() => {
+      result.current.recordError();
+      result.current.recordRetrySuccess();
+      result.current.recordRetryFailure();
+    });
+    act(() => result.current.resetMetrics());
+
+    expect(result.current.metrics).toEqual({
+      totalErrors: 0,
+      totalRetries: 0,
+      successfulRetries: 0,
+      failedRetries: 0,
+      successRate: 0,
+    });
+  });
+
+  it('computes successRate as successfulRetries / totalRetries (2 of 4 = 0.5)', () => {
+    const { result } = renderHook(() => useErrorBoundaryMetrics());
+
+    act(() => {
+      result.current.recordRetrySuccess();
+      result.current.recordRetrySuccess();
+      result.current.recordRetryFailure();
+      result.current.recordRetryFailure();
+    });
+
+    expect(result.current.metrics.totalRetries).toBe(4);
+    expect(result.current.metrics.successfulRetries).toBe(2);
+    expect(result.current.metrics.successRate).toBe(0.5);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Issue #376** — efficient error boundary recovery with automatic retry logic.

Adds a new `RetryErrorBoundary` class component that automatically retries **transient render errors** before ever showing an error screen, and wires it in at the app root (inside the existing `ErrorBoundary`, which is preserved).

### Retry strategy
- **Max 3 retries** before the fallback UI is shown.
- **Exponential backoff**: `baseDelayMs * 2^retryCount`, capped at 10,000 ms.
  - With defaults (`baseDelayMs=500`): **500ms → 1000ms → 2000ms**, then fallback.
- A subtle `ActivityIndicator` is shown while a retry is pending; children only re-render once the error clears.
- All retry events are logged via the centralised `appLogger` (`errorSync`/`warnSync`/`infoSync`).

### Transient vs non-transient classification
- By default **every** caught error is treated as transient (retried).
- An optional `isTransient: (error) => boolean` prop lets callers retry only specific errors (e.g. network/timeout). When it returns `false`, retries are skipped and the fallback is shown immediately (calling `onMaxRetriesReached`).

### What's included
- `components/ErrorBoundary/RetryErrorBoundary.tsx` — the retry boundary (class component; `getDerivedStateFromError` + `componentDidCatch` + backoff scheduling + success detection in `componentDidUpdate` + timeout cleanup).
- `components/ErrorBoundary/DefaultErrorFallback.tsx` — NativeWind fallback UI; shows the raw error only in `__DEV__`; accessible "Try Again" button.
- `hooks/useErrorBoundaryMetrics.ts` — in-memory retry-metrics store (state-based, derived `successRate`).
- `app/_layout.tsx` — wires `RetryErrorBoundary` at the root (existing `ErrorBoundary` kept as outer boundary).
- `tests/components/RetryErrorBoundary.test.tsx`, `tests/hooks/useErrorBoundaryMetrics.test.ts` — 15 tests (fake-timer backoff assertions, max-retries, success/failure callbacks, `isTransient=false`, manual-retry reset, unmount cleanup).
- `docs/error-boundary-retry-strategy.md` — strategy, props reference, usage examples, when-not-to-use, transient classification.

## Verification
- ✅ `npx tsc --noEmit` — **zero errors in the files this PR touches**. (Pre-existing syntax errors in `src/components/mobile/LessonCarousel.tsx` and `MobileQuizManager/QuizCarousel.tsx` exist on `main` and are out of scope.)
- ✅ `npm test` — the **15 new tests pass**. The full-suite failures (`abTesting`, `MobileSearch.perf`, `InfiniteVirtualList`, `AdvancedDataGrid`, `carousel`, `DebounceIntegration`) are **pre-existing** — verified to fail identically on a clean baseline without this branch's changes.
- ✅ ESLint passes with `--max-warnings=0` on all touched files (enforced by the pre-commit hook).

### Retry flow (logs)
The backoff test asserts the exact scheduling sequence via the logger:
```
infoSync('Error boundary scheduling retry', { retryCount: 0, delayMs: 500 })
infoSync('Error boundary scheduling retry', { retryCount: 1, delayMs: 1000 })
infoSync('Error boundary scheduling retry', { retryCount: 2, delayMs: 2000 })
warnSync('Max retries reached for error boundary', { retryCount: 3, ... })
```
The fallback UI appears only after the 3rd retry fails, and pressing **Try Again** resets `retryCount` to 0 (both asserted in tests).

> Note: the live end-to-end "temporary throw in the app" check could not be run in the headless CI environment used here, but the identical code paths (scheduling-with-delay logging, fallback-only-after-3-failures, manual-retry reset) are covered deterministically with fake timers in the automated tests.

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)
