### PR TITLE
perf: add useCallback memoization to prevent unnecessary re-renders

### DIFF
--- a/docs/callback-patterns.md
+++ b/docs/callback-patterns.md
@@ -1,0 +1,250 @@
+# Callback Patterns & useCallback Guide
+
+## Overview
+
+This document describes the callback memoization patterns used across the TeachLink mobile app. Following these patterns prevents unnecessary re-renders, keeps prop references stable, and improves overall component performance.
+
+---
+
+## Why useCallback?
+
+React recreates every function defined inside a component on every render. When those functions are passed as props to child components, the child sees a new reference each time and re-renders — even if nothing meaningful changed. `useCallback` memoizes the function reference so it only changes when its declared dependencies change.
+
+**Without useCallback:**
+```tsx
+// New function reference on every render → BookmarkButton re-renders every time parent renders
+const handleToggle = async () => {
+  await addBookmark(item);
+};
+```
+
+**With useCallback:**
+```tsx
+// Stable reference → BookmarkButton only re-renders when bookmarked/item/store methods change
+const handleToggle = useCallback(async () => {
+  await addBookmark(item);
+}, [bookmarked, item, addBookmark, removeBookmark]);
+```
+
+---
+
+## Dependency Array Rules
+
+| Dependency type | Include in array? | Notes |
+|---|---|---|
+| Props | ✅ Yes | Props can change between renders |
+| Local state (`useState`) | ✅ Yes | State values change on `setState` calls |
+| Other `useCallback` / `useMemo` values | ✅ Yes | They are stable references themselves |
+| Zustand store **methods** (`addBookmark`, `setTheme`) | ✅ Yes | Zustand methods are stable but must be listed for exhaustive-deps |
+| Zustand store **state slices** (`bookmarked`, `theme`) | ✅ Yes | These are values that change |
+| `useRef` values (`.current`) | ❌ No | Refs are mutable and don't trigger re-renders |
+| Module-level constants / `StyleSheet.create` | ❌ No | Never change |
+| Setter functions from `useState` (`setFoo`) | ❌ No | React guarantees these are stable |
+
+---
+
+## Patterns Applied in This Codebase
+
+### 1. Async event handlers (BookmarkButton, DownloadButton, AvatarCamera)
+
+```tsx
+const handleToggle = useCallback(async () => {
+  if (bookmarked) {
+    await removeBookmark(item.itemId);
+  } else {
+    await addBookmark(item);
+  }
+}, [bookmarked, item, addBookmark, removeBookmark]);
+```
+
+**Why:** The handler is passed directly to `onPress`. Without memoization, the `TouchableOpacity` receives a new prop on every parent render.
+
+---
+
+### 2. Form input handlers (MobileFormInput)
+
+```tsx
+const handleBlur = useCallback(
+  (e: Parameters<NonNullable<TextInputProps['onBlur']>>[0]) => {
+    setIsFocused(false);
+    if (cacheKey && cacheOnBlur && value.trim()) {
+      void setCachedFieldValue(cacheKey, value);
+    }
+    onBlur?.(e);
+  },
+  [cacheKey, cacheOnBlur, value, onBlur]
+);
+
+const handleFocus = useCallback(() => setIsFocused(true), []);
+const handleTogglePassword = useCallback(() => setShowPassword(prev => !prev), []);
+```
+
+**Why:** `TextInput` receives these as `onFocus`/`onBlur` props. Stable references prevent the native input from receiving unnecessary prop updates.
+
+---
+
+### 3. Modal / camera handlers (AvatarCamera)
+
+```tsx
+const handleConfirm = useCallback(() => {
+  if (preview) {
+    onConfirm(preview);
+    setPreview(null);
+    resetCapturedImage();
+    onClose();
+  }
+}, [preview, onConfirm, resetCapturedImage, onClose]);
+```
+
+**Why:** `onConfirm` and `onClose` are props from the parent. Including them in the dependency array ensures the callback always calls the latest version of those props.
+
+---
+
+### 4. Settings handlers (MobileSettings)
+
+```tsx
+const handleBiometricToggle = useCallback(async (value: boolean) => {
+  if (value) {
+    const ok = await enableBiometric();
+    if (!ok) Alert.alert('Biometric Login', 'Enable failed. Check device settings.');
+  } else {
+    await disableBiometric();
+  }
+}, [enableBiometric, disableBiometric]);
+
+const handleToggleAdvanced = useCallback(() => {
+  LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+  setShowAdvancedSettings(prev => !prev);
+}, []);
+```
+
+**Why:** `handleToggleAdvanced` has an empty dependency array because it only calls `setShowAdvancedSettings` with a functional updater — no external values are captured.
+
+---
+
+### 5. Seek bar handlers (VideoControls)
+
+```tsx
+const positionFromEvent = useCallback((event: any) => {
+  if (seekBarWidth <= 0 || durationMillis <= 0) return 0;
+  const x = event.nativeEvent.locationX;
+  return clamp((x / seekBarWidth) * durationMillis, 0, durationMillis);
+}, [seekBarWidth, durationMillis]);
+
+const handleSeekGrant = useCallback((event: any) => {
+  if (!durationMillis) return;
+  onSeekStart?.();
+  const position = positionFromEvent(event);
+  onSeekPreview?.(position);
+}, [durationMillis, onSeekStart, onSeekPreview, positionFromEvent]);
+```
+
+**Why:** `positionFromEvent` is a derived helper used by three other callbacks. Memoizing it first, then listing it as a dependency of the seek handlers, creates a clean dependency chain and avoids stale closure bugs.
+
+---
+
+### 6. Swipeable row handlers (SwipeableRow)
+
+```tsx
+const triggerHaptic = useCallback(() => {
+  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
+}, []);
+
+const executeDelete = useCallback(() => {
+  isDeletedShared.value = true;
+  translationX.value = withTiming(-SCREEN_WIDTH, { duration: 200 });
+  itemHeight.value = withTiming(0, { duration: 250 }, finished => {
+    if (finished && onDelete) runOnJS(onDelete)();
+  });
+}, [isDeletedShared, translationX, itemHeight, onDelete]);
+```
+
+**Why:** `triggerHaptic` is called via `runOnJS` inside a Reanimated worklet. A stable reference prevents the gesture handler from being rebuilt on every render. Shared values from `useSharedValue` are included in the dependency array because they are objects whose identity is stable but whose `.value` is read inside the callback.
+
+---
+
+### 7. Profile handlers (MobileProfile)
+
+```tsx
+const handleToggleFollow = useCallback((connectionId: string) => {
+  setProfile(prev => ({
+    ...prev,
+    connections: prev.connections.map(c =>
+      c.id === connectionId ? { ...c, isFollowing: !c.isFollowing } : c
+    ),
+  }));
+}, []);
+```
+
+**Why:** Uses a functional `setProfile` updater so no external state is captured — empty dependency array is correct and the callback is maximally stable.
+
+---
+
+## Anti-Patterns to Avoid
+
+### ❌ Inline arrow functions on frequently-rendered components
+
+```tsx
+// Bad — new function on every render
+<TouchableOpacity onPress={() => setActiveTab(tab.key)} />
+
+// Good — stable reference
+const handleSelectTab = useCallback((tab: ProfileTab) => setActiveTab(tab), []);
+<TouchableOpacity onPress={() => handleSelectTab(tab.key)} />
+```
+
+### ❌ Missing dependencies (stale closures)
+
+```tsx
+// Bad — stale closure: value captured at creation time, never updates
+const handleSave = useCallback(async () => {
+  await save(editName); // editName is stale!
+}, []); // ← missing editName
+
+// Good
+const handleSave = useCallback(async () => {
+  await save(editName);
+}, [editName, save]);
+```
+
+### ❌ Over-memoizing trivial callbacks
+
+```tsx
+// Unnecessary — this component renders rarely and has no memo-wrapped children
+const handlePress = useCallback(() => navigate('Home'), [navigate]);
+```
+
+Only apply `useCallback` when:
+- The function is passed as a prop to a child component
+- The function is used in a `useEffect` / `useMemo` dependency array
+- The function is called via `runOnJS` in a Reanimated worklet
+- The component renders frequently (list items, video controls, form inputs)
+
+---
+
+## ESLint Enforcement
+
+The following rules are active in `eslint.config.js`:
+
+```js
+'react-hooks/rules-of-hooks': 'error',        // Hooks must follow the Rules of Hooks
+'react-hooks/exhaustive-deps': 'warn',         // Dependency arrays must be complete
+'react/no-unstable-nested-components': 'warn', // No inline component definitions
+```
+
+`exhaustive-deps` is set to `warn` (not `error`) to allow intentional empty arrays where functional updaters make them safe. Always add a comment when intentionally omitting a dependency.
+
+---
+
+## Files Updated
+
+| File | Callbacks memoized |
+|---|---|
+| `BookmarkButton.tsx` | `handleToggle` |
+| `DownloadButton.tsx` | `handlePress`, `renderIcon`, `getLabel` |
+| `AvatarCamera.tsx` | `handleTakePhoto`, `handlePickFromLibrary`, `handleConfirm`, `handleRetake`, `handleClose` |
+| `MobileFormInput.tsx` | `handleBlur`, `handleApplySuggestion`, `handleFocus`, `handleTogglePassword` |
+| `MobileSettings.tsx` | `handleClearFormCache`, `handleBiometricToggle`, `handleSignOut`, `handleManualSync`, `handleClearDownloads`, `handleToggleAdvanced` |
+| `VideoControls.tsx` | `handleSeekBarLayout`, `positionFromEvent`, `handleSeekGrant`, `handleSeekMove`, `handleSeekRelease`, `handleSeekTerminate`, `handleToggleSpeedMenu`, `handleToggleQualityMenu`, `handleSelectRate`, `handleSelectQualityOption` |
+| `SwipeableRow.tsx` | `triggerHaptic`, `handleLayout`, `executeDelete`, `executeArchive` |
+| `MobileProfile.tsx` | `getInitials`, `handleStartEdit`, `handleToggleAdvancedFields`, `validateForm`, `handleSave`, `handleCancelEdit`, `handleAvatarConfirm`, `handleToggleFollow`, `handleOpenCamera`, `handleCloseCamera`, `handleSelectTab` |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,8 +59,11 @@ module.exports = defineConfig([
         },
       ],
 
-      'react-hooks/rules-of-hooks': 'warn',
+      'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',
+
+      // Prevent inline component definitions that defeat memoization
+      'react/no-unstable-nested-components': ['warn', { allowAsProps: false }],
 
       'jsx-a11y/alt-text': 'warn',
       'jsx-a11y/aria-props': 'warn',

--- a/src/components/mobile/AvatarCamera.tsx
+++ b/src/components/mobile/AvatarCamera.tsx
@@ -1,6 +1,6 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import { Camera, Check, ImageIcon, RefreshCw, X } from 'lucide-react-native';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   ActivityIndicator,
   Modal,
@@ -37,35 +37,35 @@ export const AvatarCamera: React.FC<AvatarCameraProps> = ({
   const { isLoading, takePicture, pickFromLibrary, resetCapturedImage } = useCamera();
   const [preview, setPreview] = useState<string | null>(null);
 
-  const handleTakePhoto = async () => {
+  const handleTakePhoto = useCallback(async () => {
     const uri = await takePicture();
     if (uri) setPreview(uri);
-  };
+  }, [takePicture]);
 
-  const handlePickFromLibrary = async () => {
+  const handlePickFromLibrary = useCallback(async () => {
     const uri = await pickFromLibrary();
     if (uri) setPreview(uri);
-  };
+  }, [pickFromLibrary]);
 
-  const handleConfirm = () => {
+  const handleConfirm = useCallback(() => {
     if (preview) {
       onConfirm(preview);
       setPreview(null);
       resetCapturedImage();
       onClose();
     }
-  };
+  }, [preview, onConfirm, resetCapturedImage, onClose]);
 
-  const handleRetake = () => {
+  const handleRetake = useCallback(() => {
     setPreview(null);
     resetCapturedImage();
-  };
+  }, [resetCapturedImage]);
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     setPreview(null);
     resetCapturedImage();
     onClose();
-  };
+  }, [resetCapturedImage, onClose]);
 
   return (
     <ErrorBoundary boundaryName="AvatarCameraModal">

--- a/src/components/mobile/BookmarkButton.tsx
+++ b/src/components/mobile/BookmarkButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { TouchableOpacity, Text, ActivityIndicator, View, StyleSheet } from 'react-native';
 
 import { useBookmarkStore, BookmarkItem } from '../../store/bookmarkStore';
@@ -24,13 +24,13 @@ export default function BookmarkButton({
   };
   const config = sizeConfig[size];
 
-  const handleToggle = async () => {
+  const handleToggle = useCallback(async () => {
     if (bookmarked) {
       await removeBookmark(item.itemId);
     } else {
       await addBookmark(item);
     }
-  };
+  }, [bookmarked, item, addBookmark, removeBookmark]);
 
   const backgroundColor = bookmarked ? '#fef3c7' : '#f3f4f6';
   const borderColor = bookmarked ? '#facc15' : '#d1d5db';

--- a/src/components/mobile/DownloadButton.tsx
+++ b/src/components/mobile/DownloadButton.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { CheckCircle2, Clock, Download, XCircle } from 'lucide-react-native';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { ActivityIndicator, TouchableOpacity, View } from 'react-native';
 import { useDownloads } from '../../hooks/useDownloads';
 import { useDynamicFontSize } from '../../hooks/useDynamicFontSize';
@@ -20,7 +20,7 @@ export function DownloadButton({ id, title, url, size, className }: DownloadButt
 
   const task = tasks.find(t => t.id === id);
 
-  const handlePress = async () => {
+  const handlePress = useCallback(async () => {
     if (!task) {
       try {
         await startDownload(id, title, url, size);
@@ -30,9 +30,9 @@ export function DownloadButton({ id, title, url, size, className }: DownloadButt
     } else if (task.status === 'completed') {
       removeDownload(id);
     }
-  };
+  }, [task, id, title, url, size, startDownload, removeDownload]);
 
-  const renderIcon = () => {
+  const renderIcon = useCallback(() => {
     if (!task) return <Download size={scale(20)} color="#4B5563" />;
 
     switch (task.status) {
@@ -47,15 +47,15 @@ export function DownloadButton({ id, title, url, size, className }: DownloadButt
       default:
         return <Download size={scale(20)} color="#4B5563" />;
     }
-  };
+  }, [task, scale]);
 
-  const getLabel = () => {
+  const getLabel = useCallback(() => {
     if (!task) return 'Download';
     if (task.status === 'downloading') return `${Math.round(task.progress * 100)}%`;
     if (task.status === 'queued') return 'Queued';
     if (task.status === 'completed') return 'Offline';
     return 'Retry';
-  };
+  }, [task]);
 
   return (
     <TouchableOpacity

--- a/src/components/mobile/MobileFormInput.tsx
+++ b/src/components/mobile/MobileFormInput.tsx
@@ -1,5 +1,5 @@
 import { Eye, EyeOff, AlertCircle } from 'lucide-react-native';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { View, TextInput, TextInputProps, TouchableOpacity, StyleSheet } from 'react-native';
 
 import { useDynamicFontSize } from '../../hooks';
@@ -81,20 +81,24 @@ export const MobileFormInput: React.FC<MobileFormInputProps> = ({
     };
   }, [cacheKey, isFocused, value]);
 
-  const handleBlur = (e: Parameters<NonNullable<TextInputProps['onBlur']>>[0]) => {
+  const handleBlur = useCallback((e: Parameters<NonNullable<TextInputProps['onBlur']>>[0]) => {
     setIsFocused(false);
     if (cacheKey && cacheOnBlur && value.trim()) {
       void setCachedFieldValue(cacheKey, value);
     }
     onBlur?.(e);
-  };
+  }, [cacheKey, cacheOnBlur, value, onBlur]);
 
-  const handleApplySuggestion = () => {
+  const handleApplySuggestion = useCallback(() => {
     if (suggestion) {
       onChangeText(suggestion);
       setSuggestion(null);
     }
-  };
+  }, [suggestion, onChangeText]);
+
+  const handleFocus = useCallback(() => setIsFocused(true), []);
+
+  const handleTogglePassword = useCallback(() => setShowPassword(prev => !prev), []);
 
   const borderColor = error ? '#ef4444' : isFocused ? '#19c3e6' : isDark ? '#334155' : '#e2e8f0';
 
@@ -144,7 +148,7 @@ export const MobileFormInput: React.FC<MobileFormInputProps> = ({
           value={value}
           onChangeText={onChangeText}
           ref={inputRef}
-          onFocus={() => setIsFocused(true)}
+          onFocus={handleFocus}
           onBlur={handleBlur}
           secureTextEntry={isPassword && !showPassword}
           multiline={multiline}
@@ -153,7 +157,7 @@ export const MobileFormInput: React.FC<MobileFormInputProps> = ({
         />
 
         {isPassword && (
-          <TouchableOpacity onPress={() => setShowPassword(!showPassword)} style={styles.rightIcon}>
+          <TouchableOpacity onPress={handleTogglePassword} style={styles.rightIcon}>
             {showPassword ? (
               <EyeOff size={scale(20)} color={isDark ? '#64748b' : '#94a3b8'} />
             ) : (

--- a/src/components/mobile/MobileProfile.tsx
+++ b/src/components/mobile/MobileProfile.tsx
@@ -17,7 +17,7 @@ import {
   Users,
   X,
 } from 'lucide-react-native';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Animated,
@@ -354,15 +354,16 @@ export const MobileProfile: React.FC<MobileProfileProps> = ({
   const textSecondary = isDark ? '#94a3b8' : '#64748b';
   const borderColor = isDark ? '#334155' : '#e2e8f0';
 
-  const getInitials = (name: string) =>
+  const getInitials = useCallback((name: string) =>
     name
       .split(' ')
       .map(n => n[0])
       .join('')
       .toUpperCase()
-      .slice(0, 2);
+      .slice(0, 2),
+  []);
 
-  const handleStartEdit = () => {
+  const handleStartEdit = useCallback(() => {
     setEditName(profile.name);
     setEditBio(profile.bio);
     setEditEmail(profile.email);
@@ -387,22 +388,22 @@ export const MobileProfile: React.FC<MobileProfileProps> = ({
     setFormErrors({});
     setShowAdvancedFields(false); // reset disclosure state on each edit session
     setIsEditing(true);
-  };
+  }, [profile, applyPrefillToFields]);
 
-  const handleToggleAdvancedFields = () => {
+  const handleToggleAdvancedFields = useCallback(() => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     setShowAdvancedFields(prev => !prev);
-  };
+  }, []);
 
-  const validateForm = (): Record<string, string> => {
+  const validateForm = useCallback((): Record<string, string> => {
     const errors: Record<string, string> = {};
     if (!editName.trim()) errors.name = 'Name is required';
     if (!editEmail.trim()) errors.email = 'Email is required';
     else if (!/\S+@\S+\.\S+/.test(editEmail)) errors.email = 'Enter a valid email address';
     return errors;
-  };
+  }, [editName, editEmail]);
 
-  const handleSave = async () => {
+  const handleSave = useCallback(async () => {
     const errors = validateForm();
     if (Object.keys(errors).length > 0) {
       setFormErrors(errors);
@@ -428,25 +429,30 @@ export const MobileProfile: React.FC<MobileProfileProps> = ({
     });
     setIsSaving(false);
     setIsEditing(false);
-  };
+  }, [validateForm, editName, editBio, editEmail, editLocation, editWebsite, persistFields]);
 
-  const handleCancelEdit = () => {
+  const handleCancelEdit = useCallback(() => {
     setIsEditing(false);
     setFormErrors({});
-  };
+  }, []);
 
-  const handleAvatarConfirm = (uri: string) => {
+  const handleAvatarConfirm = useCallback((uri: string) => {
     setProfile(prev => ({ ...prev, avatar: uri }));
-  };
+  }, []);
 
-  const handleToggleFollow = (connectionId: string) => {
+  const handleToggleFollow = useCallback((connectionId: string) => {
     setProfile(prev => ({
       ...prev,
       connections: prev.connections.map(c =>
         c.id === connectionId ? { ...c, isFollowing: !c.isFollowing } : c
       ),
     }));
-  };
+  }, []);
+
+  const handleOpenCamera = useCallback(() => setIsCameraVisible(true), []);
+  const handleCloseCamera = useCallback(() => setIsCameraVisible(false), []);
+
+  const handleSelectTab = useCallback((tab: ProfileTab) => setActiveTab(tab), []);
 
   // Tab config
   const TABS: { key: ProfileTab; label: string }[] = [
@@ -503,7 +509,7 @@ export const MobileProfile: React.FC<MobileProfileProps> = ({
           <View style={styles.avatarRow}>
             <TouchableOpacity
               style={styles.avatarContainer}
-              onPress={() => setIsCameraVisible(true)}
+            onPress={handleOpenCamera}
               activeOpacity={0.85}
               accessibilityRole="button"
               accessibilityLabel="Change avatar"
@@ -643,7 +649,7 @@ export const MobileProfile: React.FC<MobileProfileProps> = ({
             <TouchableOpacity
               key={tab.key}
               style={styles.tabItem}
-              onPress={() => setActiveTab(tab.key)}
+              onPress={() => handleSelectTab(tab.key)}
               accessibilityRole="tab"
               accessibilityState={{ selected: activeTab === tab.key }}
               accessibilityLabel={`${tab.label} tab`}
@@ -916,7 +922,7 @@ export const MobileProfile: React.FC<MobileProfileProps> = ({
         visible={isCameraVisible}
         currentAvatar={profile.avatar}
         onConfirm={handleAvatarConfirm}
-        onClose={() => setIsCameraVisible(false)}
+        onClose={handleCloseCamera}
       />
     </SafeAreaView>
   );

--- a/src/components/mobile/MobileSettings.tsx
+++ b/src/components/mobile/MobileSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   Alert,
   ActivityIndicator,
@@ -236,7 +236,7 @@ export function MobileSettings({
   const { scale } = useDynamicFontSize();
   const { clearCache: clearStoredFormFields } = useFormCache([]);
 
-  const handleClearFormCache = () => {
+  const handleClearFormCache = useCallback(() => {
     Alert.alert(
       'Clear Cached Form Data',
       'Remove saved names, emails, and addresses from this device?',
@@ -252,9 +252,9 @@ export function MobileSettings({
         },
       ]
     );
-  };
+  }, [clearStoredFormFields]);
 
-  const handleBiometricToggle = async (value: boolean) => {
+  const handleBiometricToggle = useCallback(async (value: boolean) => {
     if (value) {
       const ok = await enableBiometric();
       if (!ok) {
@@ -263,16 +263,16 @@ export function MobileSettings({
     } else {
       await disableBiometric();
     }
-  };
+  }, [enableBiometric, disableBiometric]);
 
-  const handleSignOut = () => {
+  const handleSignOut = useCallback(() => {
     Alert.alert('Sign Out', 'Are you sure?', [
       { text: 'Cancel', style: 'cancel' },
       { text: 'Sign Out', style: 'destructive', onPress: onSignOut },
     ]);
-  };
+  }, [onSignOut]);
 
-  const handleManualSync = async () => {
+  const handleManualSync = useCallback(async () => {
     Alert.alert('Sync', 'Sync data with server?', [
       { text: 'Cancel', style: 'cancel' },
       {
@@ -288,19 +288,19 @@ export function MobileSettings({
         },
       },
     ]);
-  };
+  }, []);
 
-  const handleClearDownloads = () => {
+  const handleClearDownloads = useCallback(() => {
     Alert.alert('Clear Downloads', 'Remove all downloads?', [
       { text: 'Cancel', style: 'cancel' },
       { text: 'Clear', style: 'destructive' },
     ]);
-  };
+  }, []);
 
-  const handleToggleAdvanced = () => {
+  const handleToggleAdvanced = useCallback(() => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     setShowAdvancedSettings(prev => !prev);
-  };
+  }, []);
 
   return (
     <ScrollView className="flex-1 bg-gray-50 dark:bg-gray-900">

--- a/src/components/mobile/SwipeableRow.tsx
+++ b/src/components/mobile/SwipeableRow.tsx
@@ -1,6 +1,6 @@
 import * as Haptics from 'expo-haptics';
 import { Trash2, Archive } from 'lucide-react-native';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   StyleSheet,
   View,
@@ -80,9 +80,9 @@ export const SwipeableRow: React.FC<SwipeableRowProps> = ({
   }, [id, isDeletedShared, isHapticTriggered, translationX]);
 
   // Haptic feedback trigger on JavaScript thread
-  const triggerHaptic = () => {
+  const triggerHaptic = useCallback(() => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
-  };
+  }, []);
 
   const panGesture = Gesture.Pan()
     .activeOffsetX([-10, 10]) // Don't intercept minor horizontal scroll/clicks
@@ -132,15 +132,15 @@ export const SwipeableRow: React.FC<SwipeableRowProps> = ({
       }
     });
 
-  const handleLayout = (event: LayoutChangeEvent) => {
+  const handleLayout = useCallback((event: LayoutChangeEvent) => {
     if (layoutHeight === null) {
       const { height } = event.nativeEvent.layout;
       setLayoutHeight(height);
       itemHeight.value = height;
     }
-  };
+  }, [layoutHeight, itemHeight]);
 
-  const executeDelete = () => {
+  const executeDelete = useCallback(() => {
     isDeletedShared.value = true;
     translationX.value = withTiming(-SCREEN_WIDTH, { duration: 200 });
     itemHeight.value = withTiming(0, { duration: 250 }, finished => {
@@ -148,15 +148,15 @@ export const SwipeableRow: React.FC<SwipeableRowProps> = ({
         runOnJS(onDelete)();
       }
     });
-  };
+  }, [isDeletedShared, translationX, itemHeight, onDelete]);
 
-  const executeArchive = () => {
+  const executeArchive = useCallback(() => {
     translationX.value = withTiming(SCREEN_WIDTH, { duration: 200 }, finished => {
       if (finished && onArchive) {
         runOnJS(onArchive)();
       }
     });
-  };
+  }, [translationX, onArchive]);
 
   const animatedRowStyle = useAnimatedStyle(() => {
     const height = itemHeight.value !== null ? itemHeight.value : 'auto';

--- a/src/components/mobile/VideoControls.tsx
+++ b/src/components/mobile/VideoControls.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, Pressable, StyleSheet, Text, View } from 'react-native';
 import type { QualityOption } from '../../services/videoQuality';
 
@@ -95,47 +95,65 @@ const VideoControls = ({
     return selected?.label ?? 'Auto';
   }, [qualityOptions, selectedQualityId]);
 
-  const handleSeekBarLayout = (event: any) => {
+  const handleSeekBarLayout = useCallback((event: any) => {
     setSeekBarWidth(event.nativeEvent.layout.width);
-  };
+  }, []);
 
-  const positionFromEvent = (event: any) => {
+  const positionFromEvent = useCallback((event: any) => {
     if (seekBarWidth <= 0 || durationMillis <= 0) {
       return 0;
     }
     const x = event.nativeEvent.locationX;
     return clamp((x / seekBarWidth) * durationMillis, 0, durationMillis);
-  };
+  }, [seekBarWidth, durationMillis]);
 
-  const handleSeekGrant = (event: any) => {
+  const handleSeekGrant = useCallback((event: any) => {
     if (!durationMillis) {
       return;
     }
     onSeekStart?.();
     const position = positionFromEvent(event);
     onSeekPreview?.(position);
-  };
+  }, [durationMillis, onSeekStart, onSeekPreview, positionFromEvent]);
 
-  const handleSeekMove = (event: any) => {
+  const handleSeekMove = useCallback((event: any) => {
     if (!durationMillis) {
       return;
     }
     const position = positionFromEvent(event);
     onSeekPreview?.(position);
-  };
+  }, [durationMillis, onSeekPreview, positionFromEvent]);
 
-  const handleSeekRelease = (event: any) => {
+  const handleSeekRelease = useCallback((event: any) => {
     if (!durationMillis) {
       return;
     }
     const position = positionFromEvent(event);
     onSeek(position);
     onSeekEnd?.();
-  };
+  }, [durationMillis, positionFromEvent, onSeek, onSeekEnd]);
 
-  const handleSeekTerminate = () => {
+  const handleSeekTerminate = useCallback(() => {
     onSeekEnd?.();
-  };
+  }, [onSeekEnd]);
+
+  const handleToggleSpeedMenu = useCallback(() => {
+    setIsSpeedMenuOpen(prev => !prev);
+  }, []);
+
+  const handleToggleQualityMenu = useCallback(() => {
+    setIsQualityMenuOpen(prev => !prev);
+  }, []);
+
+  const handleSelectRate = useCallback((rate: number) => {
+    onChangeRate(rate);
+    setIsSpeedMenuOpen(false);
+  }, [onChangeRate]);
+
+  const handleSelectQualityOption = useCallback((qualityId: string) => {
+    onSelectQuality(qualityId);
+    setIsQualityMenuOpen(false);
+  }, [onSelectQuality]);
 
   return (
     <Animated.View pointerEvents={visible ? 'auto' : 'none'} style={[styles.overlay, { opacity }]}>
@@ -202,14 +220,14 @@ const VideoControls = ({
         <View style={styles.controlsRow}>
           <Pressable
             accessibilityLabel="Playback speed"
-            onPress={() => setIsSpeedMenuOpen(prev => !prev)}
+            onPress={handleToggleSpeedMenu}
             style={styles.controlButton}
           >
             <Text style={styles.controlText}>{formatRate(playbackRate)}</Text>
           </Pressable>
           <Pressable
             accessibilityLabel="Quality"
-            onPress={() => setIsQualityMenuOpen(prev => !prev)}
+            onPress={handleToggleQualityMenu}
             style={styles.controlButton}
           >
             <Text style={styles.controlText}>{qualityLabel}</Text>
@@ -242,10 +260,7 @@ const VideoControls = ({
                   <Pressable
                     key={rate}
                     accessibilityLabel={`Set playback speed ${formatRate(rate)}`}
-                    onPress={() => {
-                      onChangeRate(rate);
-                      setIsSpeedMenuOpen(false);
-                    }}
+                    onPress={() => handleSelectRate(rate)}
                     style={styles.menuItem}
                   >
                     <Text
@@ -267,10 +282,7 @@ const VideoControls = ({
                   <Pressable
                     key={option.id}
                     accessibilityLabel={`Set quality ${option.label}`}
-                    onPress={() => {
-                      onSelectQuality(option.id);
-                      setIsQualityMenuOpen(false);
-                    }}
+                    onPress={() => handleSelectQualityOption(option.id)}
                     style={styles.menuItem}
                   >
                     <Text


### PR DESCRIPTION
closes #348 

## Summary
Audit and wrap all un-memoized callbacks across 8 components with useCallback and correct dependency arrays to prevent unnecessary callback recreation and downstream re-renders.

## Changes

### Components updated
- **BookmarkButton** — `handleToggle`
- **DownloadButton** — `handlePress`, `renderIcon`, `getLabel`
- **AvatarCamera** — `handleTakePhoto`, `handlePickFromLibrary`, `handleConfirm`, `handleRetake`, `handleClose`
- **MobileFormInput** — `handleBlur`, `handleApplySuggestion`, `handleFocus`, `handleTogglePassword` + replaced inline JSX arrow functions
- **MobileSettings** — `handleClearFormCache`, `handleBiometricToggle`, `handleSignOut`, `handleManualSync`, `handleClearDownloads`, `handleToggleAdvanced`
- **VideoControls** — `positionFromEvent`, `handleSeekBarLayout`, `handleSeekGrant`, `handleSeekMove`, `handleSeekRelease`, `handleSeekTerminate`, `handleToggleSpeedMenu`, `handleToggleQualityMenu`, `handleSelectRate`, `handleSelectQualityOption`
- **SwipeableRow** — `triggerHaptic`, `handleLayout`, `executeDelete`, `executeArchive`
- **MobileProfile** — `getInitials`, `handleStartEdit`, `handleToggleAdvancedFields`, `validateForm`, `handleSave`, `handleCancelEdit`, `handleAvatarConfirm`, `handleToggleFollow`, `handleOpenCamera`, `handleCloseCamera`, `handleSelectTab`

### ESLint
- Upgraded `react-hooks/rules-of-hooks` from `warn` to `error`
- Added `react/no-unstable-nested-components: warn` to catch inline component definitions that defeat memoization

### Docs
- Added `docs/callback-patterns.md` with patterns, dependency array rules, anti-patterns, and a per-file change table

## Impact
- ⚡ Reduced downstream re-renders from stable callback references
- 📊 More stable prop comparison for memo-wrapped consumers
- 🎯 Better component optimization foundation

Closes #5 #7 #29
