### PR TITLE
Optimize theme switching to avoid full app re-render by replacing use…

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -5,10 +5,10 @@ import { ErrorBoundary } from '@/components/common/ErrorBoundary';
 import { HapticTab } from '@/components/haptic-tab';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { Colors } from '@/constants/theme';
-import { useColorScheme } from '@/hooks/use-color-scheme';
+import { useTheme } from '@/store';
 
 const TabLayout = () => {
-  const colorScheme = useColorScheme();
+  const theme = useTheme();
 
   return (
     <ErrorBoundary boundaryName="TabsLayout">
@@ -16,7 +16,7 @@ const TabLayout = () => {
         // Keep all tab screens mounted so state and scroll positions survive tab switches
         detachInactiveScreens={false}
         screenOptions={{
-          tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
+          tabBarActiveTintColor: Colors[theme].tint,
           headerShown: false,
           tabBarButton: HapticTab,
         }}

--- a/components/parallax-scroll-view.tsx
+++ b/components/parallax-scroll-view.tsx
@@ -8,8 +8,8 @@ import Animated, {
 } from 'react-native-reanimated';
 
 import { ThemedView } from '@/components/themed-view';
-import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useThemeColor } from '@/hooks/use-theme-color';
+import { useTheme } from '@/store';
 
 const HEADER_HEIGHT = 250;
 
@@ -24,7 +24,7 @@ export default function ParallaxScrollView({
   headerBackgroundColor,
 }: Props) {
   const backgroundColor = useThemeColor({}, 'background');
-  const colorScheme = useColorScheme() ?? 'light';
+  const colorScheme = useTheme();
   const scrollRef = useAnimatedRef<Animated.ScrollView>();
   const scrollOffset = useScrollOffset(scrollRef);
   const headerAnimatedStyle = useAnimatedStyle(() => {

--- a/components/ui/collapsible.tsx
+++ b/components/ui/collapsible.tsx
@@ -5,11 +5,11 @@ import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { Colors } from '@/constants/theme';
-import { useColorScheme } from '@/hooks/use-color-scheme';
+import { useTheme } from '@/store';
 
 export function Collapsible({ children, title }: PropsWithChildren & { title: string }) {
   const [isOpen, setIsOpen] = useState(false);
-  const theme = useColorScheme() ?? 'light';
+  const theme = useTheme();
 
   return (
     <ThemedView>

--- a/hooks/use-color-scheme.ts
+++ b/hooks/use-color-scheme.ts
@@ -1,1 +1,0 @@
-export { useColorScheme } from 'react-native';

--- a/hooks/use-theme-color.ts
+++ b/hooks/use-theme-color.ts
@@ -4,13 +4,13 @@
  */
 
 import { Colors } from '@/constants/theme';
-import { useColorScheme } from '@/hooks/use-color-scheme';
+import { useTheme } from '@/store';
 
 export function useThemeColor(
   props: { light?: string; dark?: string },
   colorName: keyof typeof Colors.light & keyof typeof Colors.dark
 ) {
-  const theme = useColorScheme() ?? 'light';
+  const theme = useTheme();
   const colorFromProps = props[theme];
 
   if (colorFromProps) {

--- a/src/hooks/useAdaptiveTheme.ts
+++ b/src/hooks/useAdaptiveTheme.ts
@@ -4,6 +4,7 @@ import { AppState, type AppStateStatus } from 'react-native';
 
 import { useAppStore } from '../store';
 import { useSettingsStore } from '../store/settingsStore';
+import { useTheme } from '../store';
 
 export const DARK_LUX_THRESHOLD = 25;
 export const LIGHT_LUX_THRESHOLD = 75;
@@ -77,7 +78,7 @@ export function useAdaptiveTheme(): void {
     };
 
     const handleReading = (lux: number) => {
-      const currentTheme = useAppStore.getState().theme;
+      const currentTheme = useTheme(); // Changed from useAppStore.getState().theme
       const { state, confirmedTheme } = advanceDebounce(debounceRef.current, lux, currentTheme);
       debounceRef.current = state;
       if (confirmedTheme) {


### PR DESCRIPTION
Changes made:

Updated useThemeColor hook to use useTheme from store
Replaced useColorScheme with useTheme in:
app/(tabs)/_layout.tsx
components/parallax-scroll-view.tsx
components/ui/collapsible.tsx
src/hooks/useAdaptiveTheme.ts
Removed unused hooks/use-color-scheme.ts file                                                                                                                                                        closes #363 