### PR TITLE
Strip production debug code

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,8 +3,6 @@ import { StatusBar } from 'expo-status-bar';
 import React, { useEffect, useRef } from 'react';
 import { Alert, AppState, AppStateStatus, InteractionManager, LogBox } from 'react-native';
 
-
-import StorybookUI from './.rnstorybook';
 import './global.css';
 
 import * as Font from 'expo-font';
@@ -32,10 +30,6 @@ const appStartTime = Date.now();
 
 // Keep the splash screen visible while we fetch resources
 SplashScreen.preventAutoHideAsync();
-
-// SHOW_STORYBOOK flag based on environment variable
-const SHOW_STORYBOOK = process.env.EXPO_PUBLIC_STORYBOOK === 'true';
-
 
 // Centralized structured logging initialized lazily in services bootstrap useEffect
 // requireEnvVariables();
@@ -243,4 +237,9 @@ const App = () => {
   );
 };
 
-export default SHOW_STORYBOOK ? StorybookUI : App;
+const AppEntry = __DEV__ && process.env.EXPO_PUBLIC_STORYBOOK === 'true'
+  ? // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('./.rnstorybook').default
+  : App;
+
+export default AppEntry;

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,9 +1,13 @@
 module.exports = function (api) {
-  api.cache(true);
+  const isProduction = api.env(envName => envName === 'production');
+
   return {
     presets: [['babel-preset-expo', { jsxImportSource: 'nativewind' }], 'nativewind/babel'],
     plugins: [
-      require.resolve('./tools/babel-plugins/productionOptimizer'),
+      [
+        require.resolve('./tools/babel-plugins/productionOptimizer'),
+        { production: isProduction },
+      ],
       'react-native-reanimated/plugin',
     ],
   };

--- a/src/config/logging.ts
+++ b/src/config/logging.ts
@@ -72,8 +72,9 @@ export enum LogLevel {
   TRACE = 4,
 }
 
-// Default log level based on environment
-export const DEFAULT_LOG_LEVEL = isDev ? LogLevel.DEBUG : LogLevel.INFO;
+// Keep production runtime logging to errors only. Warnings and lower-level
+// breadcrumbs are stripped from release builds to avoid verbose diagnostics.
+export const DEFAULT_LOG_LEVEL = isDev ? LogLevel.DEBUG : LogLevel.ERROR;
 
 // ─── LOG CONTEXT (THREAD-LOCAL STATE) ──────────────────────────────────────
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -354,13 +354,30 @@ class AppLogger {
   }
 
   warnSync(message: string, meta?: any): void {
+    if (LogLevel.WARN > this.minLevel) {
+      return;
+    }
+
     const entry = this.buildEntry(LogLevel.WARN, message, meta);
     this.outputToConsole(LogLevel.WARN, message, entry);
   }
 
   infoSync(message: string, meta?: any): void {
+    if (LogLevel.INFO > this.minLevel) {
+      return;
+    }
+
     const entry = this.buildEntry(LogLevel.INFO, message, meta);
     this.outputToConsole(LogLevel.INFO, message, entry);
+  }
+
+  debugSync(message: string, meta?: any): void {
+    if (LogLevel.DEBUG > this.minLevel) {
+      return;
+    }
+
+    const entry = this.buildEntry(LogLevel.DEBUG, message, meta);
+    this.outputToConsole(LogLevel.DEBUG, message, entry);
   }
 }
 

--- a/tests/babel/productionOptimizer.test.ts
+++ b/tests/babel/productionOptimizer.test.ts
@@ -11,6 +11,16 @@ function transform(code: string): string {
   return result?.code || '';
 }
 
+function transformProduction(code: string): string {
+  const result = transformSync(code, {
+    plugins: [[productionOptimizer, { production: true }]],
+    babelrc: false,
+    configFile: false,
+    compact: true,
+  });
+  return result?.code || '';
+}
+
 describe('productionOptimizer Babel Plugin', () => {
   describe('Object Property Shorthand Collapse', () => {
     it('should collapse property to shorthand when key and value identifiers match', () => {
@@ -101,6 +111,48 @@ describe('productionOptimizer Babel Plugin', () => {
       const input = 'const val = false || doSomething();';
       const output = transform(input);
       expect(output).toBe('const val=doSomething();');
+    });
+  });
+
+  describe('Production Debug Stripping', () => {
+    it('removes verbose console calls while retaining errors', () => {
+      const input = `
+        console.log('debug');
+        console.info('info');
+        console.warn('warn');
+        console.debug('debug');
+        console.trace('trace');
+        console.error('error');
+      `;
+      const output = transformProduction(input);
+
+      expect(output).toBe("console.error('error');");
+    });
+
+    it('removes development-only branches from production output', () => {
+      const input = `
+        if (__DEV__) {
+          require('./DevTools');
+        } else {
+          startApp();
+        }
+        const Storybook = __DEV__ && require('./.rnstorybook');
+        const AppEntry = __DEV__ && process.env.EXPO_PUBLIC_STORYBOOK === 'true'
+          ? Storybook
+          : App;
+      `;
+      const output = transformProduction(input);
+
+      expect(output).toBe("startApp();const Storybook=false;const AppEntry=App;");
+      expect(output).not.toContain('DevTools');
+      expect(output).not.toContain('rnstorybook');
+    });
+
+    it('does not strip verbose console calls outside production mode', () => {
+      const input = "console.log('debug');console.error('error');";
+      const output = transform(input);
+
+      expect(output).toBe("console.log('debug');console.error('error');");
     });
   });
 });

--- a/tools/babel-plugins/productionOptimizer.js
+++ b/tools/babel-plugins/productionOptimizer.js
@@ -1,5 +1,28 @@
-module.exports = function productionOptimizer(api) {
+module.exports = function productionOptimizer(api, options = {}) {
   const { types: t } = api;
+  const isProduction = Boolean(options.production);
+
+  const isDevIdentifier = node => t.isIdentifier(node, { name: '__DEV__' });
+
+  const isDevOnlyExpression = node =>
+    isDevIdentifier(node) ||
+    (t.isLogicalExpression(node, { operator: '&&' }) && isDevIdentifier(node.left));
+
+  const isConsoleMember = node =>
+    t.isMemberExpression(node) &&
+    t.isIdentifier(node.object, { name: 'console' }) &&
+    t.isIdentifier(node.property) &&
+    ['log', 'info', 'warn', 'debug', 'trace'].includes(node.property.name);
+
+  const replaceStatementWithBranch = (path, replacement) => {
+    if (!replacement) {
+      path.remove();
+    } else if (t.isBlockStatement(replacement)) {
+      path.replaceWithMultiple(replacement.body);
+    } else {
+      path.replaceWith(replacement);
+    }
+  };
 
   return {
     name: 'teachlink-production-optimizer',
@@ -20,6 +43,20 @@ module.exports = function productionOptimizer(api) {
       IfStatement(path) {
         const { node } = path;
         const test = node.test;
+
+        if (isProduction && isDevOnlyExpression(test)) {
+          replaceStatementWithBranch(path, node.alternate);
+          return;
+        }
+
+        if (
+          isProduction &&
+          t.isUnaryExpression(test, { operator: '!' }) &&
+          isDevIdentifier(test.argument)
+        ) {
+          replaceStatementWithBranch(path, node.consequent);
+          return;
+        }
 
         if (t.isBooleanLiteral(test)) {
           if (test.value === true) {
@@ -46,6 +83,20 @@ module.exports = function productionOptimizer(api) {
         const { node } = path;
         const test = node.test;
 
+        if (isProduction && isDevOnlyExpression(test)) {
+          path.replaceWith(node.alternate);
+          return;
+        }
+
+        if (
+          isProduction &&
+          t.isUnaryExpression(test, { operator: '!' }) &&
+          isDevIdentifier(test.argument)
+        ) {
+          path.replaceWith(node.consequent);
+          return;
+        }
+
         if (t.isBooleanLiteral(test)) {
           if (test.value === true) {
             path.replaceWith(node.consequent);
@@ -58,6 +109,18 @@ module.exports = function productionOptimizer(api) {
       LogicalExpression(path) {
         const { node } = path;
         const left = node.left;
+
+        if (isProduction && isDevIdentifier(left)) {
+          if (node.operator === '&&') {
+            path.replaceWith(t.booleanLiteral(false));
+            return;
+          }
+
+          if (node.operator === '||') {
+            path.replaceWith(node.right);
+            return;
+          }
+        }
 
         if (t.isBooleanLiteral(left)) {
           if (node.operator === '&&') {
@@ -73,6 +136,18 @@ module.exports = function productionOptimizer(api) {
               path.replaceWith(node.right);
             }
           }
+        }
+      },
+
+      CallExpression(path) {
+        if (!isProduction || !isConsoleMember(path.node.callee)) {
+          return;
+        }
+
+        if (path.parentPath.isExpressionStatement()) {
+          path.parentPath.remove();
+        } else {
+          path.replaceWith(t.unaryExpression('void', t.numericLiteral(0)));
         }
       }
     }


### PR DESCRIPTION
﻿Summary
- Configured the existing production Babel optimizer to strip release-only debug code without adding a dependency or changing lockfiles.
- Release transforms now remove `console.log`, `console.info`, `console.warn`, `console.debug`, and `console.trace` while retaining `console.error` for production error reporting.
- Gated Storybook/dev-only entry loading directly behind a foldable `__DEV__` branch so production bundles do not include that debug module path.
- Changed the production logger default level to `ERROR` and made sync warn/info methods respect the configured minimum level.

Issue
- Closes #242

Changes
- Updated `babel.config.js` to pass a production flag to `tools/babel-plugins/productionOptimizer` only when Babel runs in the `production` environment.
- Extended `productionOptimizer` to remove verbose console calls and fold `__DEV__` / `__DEV__ && ...` development branches in production.
- Updated `App.tsx` so Storybook is loaded only from a production-foldable dev branch instead of a static import.
- Updated logging defaults so production runtime logging keeps errors only.
- Added Babel optimizer tests covering console stripping, dev branch removal, and non-production behavior.

Validation
- Ran `npm.cmd ci --ignore-scripts`.
- Ran `npm.cmd test -- tests/babel/productionOptimizer.test.ts --runInBand`.
- Ran a production Babel smoke transform with `BABEL_ENV=production`; output reduced a Storybook/dev branch to `App` and retained only `console.error`.
- Ran `git diff --check`.
- Ran `npm.cmd test -- src/__tests__/utils/logger.test.ts --runInBand`; the logger compatibility tests passed, but the suite still failed in existing `BatchQueue` tests because current code skips dev storage unless `LOG_TO_STORAGE` is set and uses `BATCH_MAX_SIZE = 20`, while those tests expect dev buffering and batches of 100.
- Ran `npm.cmd run lint`; failed with existing repo-wide unresolved alias imports, undefined components, import-order warnings, and other unrelated lint issues.

Notes
- No lockfiles were changed.
- I did not run a full EAS APK/IPA build in this environment; the production Babel transform was smoke-tested directly.
- Bundle size reduction should be measured by CI or a local release build artifact because this change affects release transform output rather than source file size.
