### PR TITLE
feat: implement modal portal to isolate modals from parent re-renders

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -8,12 +8,12 @@ import 'react-native-reanimated';
 import '../global.css'; // NativeWind CSS
 import { MemoryProfilerOverlay } from '../components/DevTools';
 import { RetryErrorBoundary } from '../components/ErrorBoundary/RetryErrorBoundary';
-
 import { AnalyticsProvider, ErrorBoundary, OfflineIndicatorProvider } from '../src/components';
+import { ModalPortalProvider } from '../src/components/common/ModalPortal';
 import { useAnalytics } from '../src/hooks';
 import { useDeepLink } from '../src/hooks/useDeepLink';
-import { sessionRestorationService } from '../src/services/sessionRestoration';
 import { preloadService } from '../src/services/preloadService';
+import { sessionRestorationService } from '../src/services/sessionRestoration';
 import { useAppStore } from '../src/store';
 import { getPathFromDeepLink } from '../src/utils/linkParser';
 import { prefetchExternalResources } from '../src/utils/resourceHints';
@@ -36,9 +36,8 @@ const ScreenTracker = () => {
   useEffect(() => {
     if (pathname) {
       trackScreen(pathname, { segments: segments.join('/') });
-      
-      // Track and record transitions + trigger predictive preloading
 
+      // Track and record transitions + trigger predictive preloading
       if (prevPathname.current !== pathname) {
         const fromScreen = prevPathname.current;
         prevPathname.current = pathname;
@@ -48,7 +47,7 @@ const ScreenTracker = () => {
         }
 
         sessionRestorationService.saveRoute(pathname);
-        
+
         // Trigger background preloading for predicted destinations
         preloadService.preload(pathname, router);
       }
@@ -133,9 +132,27 @@ const RootLayout = () => {
 
   return (
     <ErrorBoundary boundaryName="RootLayout">
-      {/* ✅ Wrap with RetryErrorBoundary */}
       <RetryErrorBoundary>
-        <AnalyticsProvider>
-          <ScreenTracker />
-          <ThemeSync />
+        {/* ModalPortalProvider lifts modal rendering to the root, isolating modals
+            from parent re-renders. All AccessibleModal instances use this by default. */}
+        <ModalPortalProvider>
+          <AnalyticsProvider>
+            <OfflineIndicatorProvider>
+              <GestureHandlerRootView style={{ flex: 1 }}>
+                <ScreenTracker />
+                <ThemeSync />
+                <Stack>
+                  <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+                  <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
+                </Stack>
+                <MemoryProfilerOverlay />
+              </GestureHandlerRootView>
+            </OfflineIndicatorProvider>
+          </AnalyticsProvider>
+        </ModalPortalProvider>
+      </RetryErrorBoundary>
+    </ErrorBoundary>
+  );
+};
 
+export default RootLayout;

--- a/docs/modal-portal-pattern.md
+++ b/docs/modal-portal-pattern.md
@@ -1,0 +1,117 @@
+# Modal Portal Pattern
+
+## Problem
+
+React Native's `Modal` renders at the OS level, but the `Modal` _component_ still lives inside the parent's React tree. When a parent component re-renders (e.g. during a scroll event or state update), the `Modal` component re-renders too — even if the modal's own props haven't changed. This causes jank during scroll+modal interactions and degrades performance on low-end devices.
+
+## Solution
+
+The portal pattern lifts modal state to a root-level context (`ModalPortalProvider`). The `Modal` component is owned by `ModalPortalHost` — mounted once at the root — rather than by the calling component. The calling component only registers/unregisters content; it never owns the `Modal` node.
+
+```
+Before:  ParentList → re-renders → ModalComponent → re-renders Modal
+After:   ParentList → re-renders → (nothing)
+         ModalPortalHost → owns Modal, only re-renders when modal state changes
+```
+
+## Architecture
+
+```
+ModalPortalProvider          (root, holds modal registry state)
+  ├── <App />                (your component tree — re-renders freely)
+  └── ModalPortalHost        (internal, renders all registered modals)
+        ├── Modal id="a"
+        └── Modal id="b"
+```
+
+### Files
+
+| File                                        | Role                                                   |
+| ------------------------------------------- | ------------------------------------------------------ |
+| `src/components/common/ModalPortal.tsx`     | Provider, host, `useModalPortal`, `useModalPortalSafe` |
+| `src/components/common/AccessibleModal.tsx` | Updated to use portal by default (`usePortal=true`)    |
+| `app/_layout.tsx`                           | Mounts `ModalPortalProvider` at the root               |
+
+## Usage
+
+### AccessibleModal (recommended for most cases)
+
+`AccessibleModal` uses the portal automatically. No changes needed at call sites:
+
+```tsx
+<AccessibleModal
+  visible={isOpen}
+  onClose={() => setIsOpen(false)}
+  accessibilityLabel="Confirm action"
+>
+  <ConfirmContent />
+</AccessibleModal>
+```
+
+Pass `usePortal={false}` to opt out (e.g. in tests or Storybook without a provider):
+
+```tsx
+<AccessibleModal visible={true} onClose={fn} accessibilityLabel="..." usePortal={false}>
+  ...
+</AccessibleModal>
+```
+
+### useModalPortal (for custom modals)
+
+Use `useModalPortal` to register any React content as a portal modal:
+
+```tsx
+import { useModalPortal } from '@/hooks';
+
+function MyComponent() {
+  const { showModal, hideModal } = useModalPortal();
+
+  const open = () =>
+    showModal(
+      'my-modal',
+      <Modal visible transparent onRequestClose={() => hideModal('my-modal')}>
+        <MyModalContent onClose={() => hideModal('my-modal')} />
+      </Modal>
+    );
+
+  return <Button onPress={open} title="Open" />;
+}
+```
+
+`showModal(id, content)` — registers content under `id`. Calling again with the same `id` replaces the content.  
+`hideModal(id)` — removes the modal.  
+`isVisible(id)` — returns whether a modal with that id is registered.
+
+## Graceful fallback
+
+`AccessibleModal` uses `useModalPortalSafe` internally, which returns `null` instead of throwing when no provider is present. In that case it falls back to inline rendering. This means existing components work correctly in tests and Storybook without a provider.
+
+## Components using this pattern
+
+| Component            | How                                                         |
+| -------------------- | ----------------------------------------------------------- |
+| `AccessibleModal`    | Portal by default (`usePortal=true`)                        |
+| `AchievementBadges`  | Via `AccessibleModal`                                       |
+| `MobileCourseViewer` | Via `AccessibleModal`                                       |
+| `FilterSheet`        | Uses RN `Modal` directly (self-contained, no portal needed) |
+| `BiometricPrompt`    | Uses RN `Modal` directly (self-contained, no portal needed) |
+| `NotificationPrompt` | Uses RN `Modal` directly (self-contained, no portal needed) |
+| `SettingsPicker`     | Uses RN `Modal` directly (self-contained, no portal needed) |
+
+`FilterSheet`, `BiometricPrompt`, `NotificationPrompt`, and `SettingsPicker` manage their own `visible` state internally and are not typically rendered inside high-frequency re-render trees, so they don't need portal wrapping. Migrate them if profiling shows they are affected.
+
+## Testing
+
+```bash
+npx jest src/__tests__/components/ModalPortal.test.tsx tests/components/AccessibleModal.test.tsx
+```
+
+Tests cover:
+
+- Provider renders children
+- `showModal` / `hideModal` / `isVisible` lifecycle
+- Duplicate id replacement
+- `useModalPortal` throws outside provider
+- `useModalPortalSafe` returns null outside provider
+- `AccessibleModal` portal and inline rendering paths
+- Graceful fallback when no provider is present

--- a/src/__tests__/components/ModalPortal.test.tsx
+++ b/src/__tests__/components/ModalPortal.test.tsx
@@ -1,0 +1,66 @@
+import { act, render, renderHook } from '@testing-library/react-native';
+import React from 'react';
+import { Text } from 'react-native';
+
+import {
+  ModalPortalProvider,
+  useModalPortal,
+  useModalPortalSafe,
+} from '../../../src/components/common/ModalPortal';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ModalPortalProvider>{children}</ModalPortalProvider>
+);
+
+describe('ModalPortalProvider / useModalPortal', () => {
+  it('renders children', () => {
+    const { getByText } = render(
+      <ModalPortalProvider>
+        <Text>App</Text>
+      </ModalPortalProvider>
+    );
+    expect(getByText('App')).toBeTruthy();
+  });
+
+  it('showModal registers content and hideModal removes it', () => {
+    const { result } = renderHook(() => useModalPortal(), { wrapper });
+
+    act(() => {
+      result.current.showModal('test', <Text>Portal Content</Text>);
+    });
+    expect(result.current.isVisible('test')).toBe(true);
+
+    act(() => {
+      result.current.hideModal('test');
+    });
+    expect(result.current.isVisible('test')).toBe(false);
+  });
+
+  it('showModal with same id replaces existing entry', () => {
+    const { result } = renderHook(() => useModalPortal(), { wrapper });
+
+    act(() => {
+      result.current.showModal('dup', <Text>First</Text>);
+      result.current.showModal('dup', <Text>Second</Text>);
+    });
+    expect(result.current.isVisible('dup')).toBe(true);
+
+    act(() => {
+      result.current.hideModal('dup');
+    });
+    expect(result.current.isVisible('dup')).toBe(false);
+  });
+
+  it('useModalPortal throws outside provider', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useModalPortal())).toThrow(
+      'useModalPortal must be used within a ModalPortalProvider'
+    );
+    spy.mockRestore();
+  });
+
+  it('useModalPortalSafe returns null outside provider', () => {
+    const { result } = renderHook(() => useModalPortalSafe());
+    expect(result.current).toBeNull();
+  });
+});

--- a/src/components/common/AccessibleModal.tsx
+++ b/src/components/common/AccessibleModal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import {
   Modal,
   ModalProps,
@@ -10,6 +10,7 @@ import {
   ViewStyle,
 } from 'react-native';
 
+import { useModalPortalSafe } from './ModalPortal';
 import { useFocusRestore } from '../../hooks/useFocusRestore';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 
@@ -30,12 +31,21 @@ interface AccessibleModalProps extends Omit<ModalProps, 'visible'> {
   initialFocusRef?: React.RefObject<any>;
   /** Contents of the modal */
   children: React.ReactNode;
+  /**
+   * When true, the modal is rendered via ModalPortalProvider at the root level,
+   * isolating it from parent re-renders. Requires ModalPortalProvider in the tree.
+   * Defaults to true.
+   */
+  usePortal?: boolean;
 }
 
 /**
  * A reusable accessible modal component that wraps React Native's Modal
  * and implements focus trapping (Tab trap on Web, screen reader trap on Native)
  * and focus restoration (returns focus to the triggering element on dismissal).
+ *
+ * By default renders via ModalPortalProvider to isolate from parent re-renders.
+ * Pass usePortal={false} to render inline (e.g. in tests or outside a provider).
  */
 export const AccessibleModal: React.FC<AccessibleModalProps> = ({
   visible,
@@ -46,20 +56,22 @@ export const AccessibleModal: React.FC<AccessibleModalProps> = ({
   triggerRef,
   initialFocusRef,
   children,
+  usePortal = true,
   ...modalProps
 }) => {
   const containerRef = useRef<View>(null);
 
-  // Restore focus to the trigger element when the modal is closed/dismissed
   useFocusRestore(visible, triggerRef);
-
-  // Trap focus inside the modal container when visible
   const { containerProps } = useFocusTrap(containerRef, visible, {
     initialFocusRef,
     autoFocus: true,
   });
 
-  return (
+  // Stable portal id derived from accessibilityLabel
+  const portalId = `accessible-modal:${accessibilityLabel}`;
+  const portal = useModalPortalSafe();
+
+  const modalContent = (
     <Modal
       transparent
       animationType="fade"
@@ -73,6 +85,7 @@ export const AccessibleModal: React.FC<AccessibleModalProps> = ({
           style={[styles.content, containerStyle]}
           accessibilityLabel={accessibilityLabel}
           accessibilityRole="dialog"
+          accessibilityViewIsModal
           onPress={e => e.stopPropagation()}
           {...containerProps}
         >
@@ -81,6 +94,26 @@ export const AccessibleModal: React.FC<AccessibleModalProps> = ({
       </Pressable>
     </Modal>
   );
+
+  // Register/unregister with the portal when usePortal is enabled
+  useEffect(() => {
+    if (!usePortal || !portal) return;
+    if (visible) {
+      portal.showModal(portalId, modalContent);
+    } else {
+      portal.hideModal(portalId);
+    }
+    return () => {
+      portal.hideModal(portalId);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible, usePortal, portal, portalId]);
+
+  // When portal is active, the host renders the modal — nothing to render here
+  if (usePortal && portal) return null;
+
+  // Fallback: render inline (no provider, or usePortal=false)
+  return modalContent;
 };
 
 const styles = StyleSheet.create({

--- a/src/components/common/ModalPortal.tsx
+++ b/src/components/common/ModalPortal.tsx
@@ -1,0 +1,135 @@
+/**
+ * ModalPortal — isolates modal rendering from parent component trees.
+ *
+ * React Native's Modal already renders at the OS level, but the Modal *component*
+ * still lives in the parent's React tree and re-renders whenever the parent does.
+ * The portal pattern lifts modal state to a root-level context so the Modal
+ * component is owned by ModalPortalHost (mounted once at the root) rather than
+ * by the calling component.
+ *
+ * Usage:
+ *   1. Wrap your root layout with <ModalPortalProvider>.
+ *   2. Place <ModalPortalHost /> inside the provider (typically at the end of the root layout).
+ *   3. Call useModalPortal() in any component to show/hide modals.
+ *
+ * @example
+ * // Root layout
+ * <ModalPortalProvider>
+ *   <App />
+ *   <ModalPortalHost />
+ * </ModalPortalProvider>
+ *
+ * // Any component
+ * const { showModal, hideModal } = useModalPortal();
+ * showModal('confirm', <ConfirmDialog onClose={() => hideModal('confirm')} />);
+ */
+
+import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import { View } from 'react-native';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface ModalEntry {
+  id: string;
+  content: React.ReactNode;
+}
+
+interface ModalPortalContextValue {
+  /** Register and show a modal by id. Replaces any existing modal with the same id. */
+  showModal: (id: string, content: React.ReactNode) => void;
+  /** Remove a modal by id. */
+  hideModal: (id: string) => void;
+  /** Whether a modal with the given id is currently registered. */
+  isVisible: (id: string) => boolean;
+}
+
+// ─── Context ──────────────────────────────────────────────────────────────────
+
+const ModalPortalContext = createContext<ModalPortalContextValue | null>(null);
+
+// ─── Provider ─────────────────────────────────────────────────────────────────
+
+/**
+ * Provides modal portal state to the component tree.
+ * Mount once at the application root.
+ */
+export const ModalPortalProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [modals, setModals] = useState<ModalEntry[]>([]);
+
+  // Keep a ref so callbacks don't capture stale state
+  const modalsRef = useRef(modals);
+  modalsRef.current = modals;
+
+  const showModal = useCallback((id: string, content: React.ReactNode) => {
+    setModals(prev => {
+      const exists = prev.some(m => m.id === id);
+      if (exists) {
+        return prev.map(m => (m.id === id ? { id, content } : m));
+      }
+      return [...prev, { id, content }];
+    });
+  }, []);
+
+  const hideModal = useCallback((id: string) => {
+    setModals(prev => prev.filter(m => m.id !== id));
+  }, []);
+
+  const isVisible = useCallback((id: string) => modalsRef.current.some(m => m.id === id), []);
+
+  const value = useMemo(
+    () => ({ showModal, hideModal, isVisible }),
+    [showModal, hideModal, isVisible]
+  );
+
+  return (
+    <ModalPortalContext.Provider value={value}>
+      {children}
+      {/* ModalPortalHost is rendered here so it shares the same context */}
+      <ModalPortalHost _modals={modals} />
+    </ModalPortalContext.Provider>
+  );
+};
+
+// ─── Host ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Renders all portalled modals at the root level.
+ * This component is intentionally internal — ModalPortalProvider mounts it automatically.
+ * Do NOT mount it manually; use ModalPortalProvider instead.
+ */
+const ModalPortalHost: React.FC<{ _modals: ModalEntry[] }> = React.memo(function ModalPortalHost({
+  _modals,
+}) {
+  if (_modals.length === 0) return null;
+  return (
+    <>
+      {_modals.map(({ id, content }) => (
+        <View key={id} collapsable={false} style={{ position: 'absolute', width: 0, height: 0 }}>
+          {content}
+        </View>
+      ))}
+    </>
+  );
+});
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns portal controls for showing and hiding modals.
+ * Must be used inside a ModalPortalProvider.
+ */
+export function useModalPortal(): ModalPortalContextValue {
+  const ctx = useContext(ModalPortalContext);
+  if (!ctx) {
+    throw new Error('useModalPortal must be used within a ModalPortalProvider');
+  }
+  return ctx;
+}
+
+/**
+ * Like useModalPortal but returns null instead of throwing when no provider is present.
+ * Used internally by AccessibleModal to gracefully fall back to inline rendering.
+ */
+export function useModalPortalSafe(): ModalPortalContextValue | null {
+  return useContext(ModalPortalContext);
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,6 +2,7 @@ export * from './mobile';
 
 export * from './common/AppText';
 export * from './common/AccessibleModal';
+export * from './common/ModalPortal';
 export { ErrorBoundary } from './common/ErrorBoundary';
 export type { ErrorBoundaryFallbackProps } from './common/ErrorBoundary';
 export { default as PrimaryButton } from './common/PrimaryButton';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -39,3 +39,5 @@ export * from './useHealthDashboard';
 export * from './usePredictivePreload';
 export * from './useReactProfiler';
 
+// Re-export modal portal hook for convenience
+export { useModalPortal } from '../components/common/ModalPortal';

--- a/tests/components/AccessibleModal.test.tsx
+++ b/tests/components/AccessibleModal.test.tsx
@@ -3,27 +3,61 @@ import React from 'react';
 import { Text } from 'react-native';
 
 import { AccessibleModal } from '../../src/components/common/AccessibleModal';
+import { ModalPortalProvider } from '../../src/components/common/ModalPortal';
 
 describe('AccessibleModal Component', () => {
-  it('renders children when visible is true', () => {
-    const { getByText } = render(
-      <AccessibleModal visible={true} onClose={jest.fn()} accessibilityLabel="Test Dialog">
-        <Text>Modal Content</Text>
-      </AccessibleModal>
-    );
+  describe('inline rendering (usePortal=false)', () => {
+    it('renders children when visible is true', () => {
+      const { getByText } = render(
+        <AccessibleModal
+          visible={true}
+          onClose={jest.fn()}
+          accessibilityLabel="Test Dialog"
+          usePortal={false}
+        >
+          <Text>Modal Content</Text>
+        </AccessibleModal>
+      );
+      expect(getByText('Modal Content')).toBeTruthy();
+    });
 
-    expect(getByText('Modal Content')).toBeTruthy();
+    it('sets accessibility props correctly for dialog role', () => {
+      const { getByLabelText } = render(
+        <AccessibleModal
+          visible={true}
+          onClose={jest.fn()}
+          accessibilityLabel="Test Dialog"
+          usePortal={false}
+        >
+          <Text>Content</Text>
+        </AccessibleModal>
+      );
+      const dialog = getByLabelText('Test Dialog');
+      expect(dialog.props.accessibilityRole).toBe('dialog');
+      expect(dialog.props.accessibilityViewIsModal).toBe(true);
+    });
   });
 
-  it('sets accessibility props correctly for dialog role', () => {
-    const { getByLabelText } = render(
-      <AccessibleModal visible={true} onClose={jest.fn()} accessibilityLabel="Test Dialog">
-        <Text>Content</Text>
-      </AccessibleModal>
-    );
+  describe('portal rendering (usePortal=true, default)', () => {
+    it('renders children via portal when visible', () => {
+      const { getByText } = render(
+        <ModalPortalProvider>
+          <AccessibleModal visible={true} onClose={jest.fn()} accessibilityLabel="Portal Dialog">
+            <Text>Portal Content</Text>
+          </AccessibleModal>
+        </ModalPortalProvider>
+      );
+      expect(getByText('Portal Content')).toBeTruthy();
+    });
 
-    const dialog = getByLabelText('Test Dialog');
-    expect(dialog.props.accessibilityRole).toBe('dialog');
-    expect(dialog.props.accessibilityViewIsModal).toBe(true);
+    it('falls back to inline rendering when no provider is present', () => {
+      // No ModalPortalProvider — should render inline without throwing
+      const { getByText } = render(
+        <AccessibleModal visible={true} onClose={jest.fn()} accessibilityLabel="Fallback Dialog">
+          <Text>Fallback Content</Text>
+        </AccessibleModal>
+      );
+      expect(getByText('Fallback Content')).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
- Add ModalPortalProvider/useModalPortal/useModalPortalSafe in ModalPortal.tsx
- Update AccessibleModal to use portal by default (usePortal=true)
- Mount ModalPortalProvider at root in app/_layout.tsx
- Export ModalPortalProvider from components index, useModalPortal from hooks index
- Add tests for ModalPortal and updated AccessibleModal portal paths
- Document pattern in docs/modal-portal-pattern.md

Closes #352