### PR TITLE
Implement offline-first data layer

### DIFF
--- a/docs/OFFLINE_FIRST_DATA_LAYER.md
+++ b/docs/OFFLINE_FIRST_DATA_LAYER.md
@@ -1,0 +1,47 @@
+# Offline-First Data Layer
+
+The offline-first data layer is centered on `useOfflineData`, `offlineStorage`, and `syncService`.
+Every local mutation is written to AsyncStorage before network sync is attempted, so app state
+survives process restarts, disabled network, and reconnect retries.
+
+## Mutation Flow
+
+1. `useOfflineData` stores the local record with `status: "pending"` and a version timestamp.
+2. The same mutation is added to the persisted sync queue as `CREATE`, `UPDATE`, or `DELETE`.
+3. Deletes are stored as tombstones until the server confirms sync, preventing local data loss while offline.
+4. When the device is online, `syncService.manualSync()` flushes queued operations.
+5. Successful server sync removes the operation from the queue; callers can mark records synced with `markAsSynced`.
+
+The queue is persisted under `@teachlink_sync_queue`, and repeated queued operations for the same
+endpoint and operation type are compacted to the latest payload.
+
+## Reconnect Behavior
+
+`useNetworkStatus` reports online and offline transitions. When the app comes back online,
+`useOfflineData` runs `syncAll()` once for the current connection and queues every pending or
+errored record that has not exceeded its retry budget. Online mutations also trigger an immediate
+manual sync when `autoSync` is enabled.
+
+## Conflict Resolution
+
+Conflict metadata is kept on each `OfflineDataItem`:
+
+- `baseData`: the last known synced version.
+- `serverData`: the conflicting server payload.
+- `conflictResolutionStrategy`: one of `server-wins`, `client-wins`, or `manual`.
+
+Use `markConflict(id, serverData, baseData)` when a sync response reports a conflict. Then call
+`resolveConflict` with one of these strategies:
+
+- `server-wins`: replace the local record with the server payload and queue an update.
+- `client-wins`: keep the local payload and queue it for upload.
+- `manual`: require an explicit resolved payload and queue that value for upload.
+
+Legacy strategy names `serverWins` and `clientWins` are normalized to the hyphenated names.
+
+## Sync Monitoring
+
+`syncService.getSyncStats()` reports pending operations, failed operations, success count,
+failure count, conflict count, last sync time, and success rate. `useOfflineData` subscribes to
+sync events and exposes those metrics as `syncSuccessRate`, `syncSuccessCount`,
+`syncFailureCount`, and `syncConflictCount`.

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -13,7 +13,6 @@ jest.mock('react-native', () => ({
   KeyboardAvoidingView: 'KeyboardAvoidingView',
   Modal: 'Modal',
   SafeAreaView: 'SafeAreaView',
-  KeyboardAvoidingView: 'KeyboardAvoidingView',
   ScrollView: 'ScrollView',
   Switch: 'Switch',
   TextInput: 'TextInput',
@@ -300,6 +299,12 @@ jest.mock('expo-notifications', () => ({
 
 // Mock expo-battery
 jest.mock('expo-battery', () => ({
+  BatteryState: {
+    UNKNOWN: 0,
+    UNPLUGGED: 1,
+    CHARGING: 2,
+    FULL: 3,
+  },
   useLowPowerMode: jest.fn(() => false),
   isLowPowerModeEnabledAsync: jest.fn(() => Promise.resolve(false)),
   getBatteryLevelAsync: jest.fn(() => Promise.resolve(1)),
@@ -310,18 +315,22 @@ jest.mock('expo-battery', () => ({
 }));
 
 // Lightweight mock for expo-router to avoid pulling in navigation internals during tests
-jest.mock('expo-router', () => ({
-  useRouter: () => ({
-    push: jest.fn(),
-    replace: jest.fn(),
-    back: jest.fn(),
-    prefetch: jest.fn(),
+jest.mock(
+  'expo-router',
+  () => ({
+    useRouter: () => ({
+      push: jest.fn(),
+      replace: jest.fn(),
+      back: jest.fn(),
+      prefetch: jest.fn(),
+    }),
+    Link: ({ children }) => children,
+    useLocalSearchParams: () => ({}),
+    usePathname: () => '/',
+    useSegments: () => [],
   }),
-  Link: ({ children }) => children,
-  useLocalSearchParams: () => ({}),
-  usePathname: () => '/',
-  useSegments: () => [],
-}), { virtual: true });
+  { virtual: true }
+);
 
 // Mock expo-document-picker and expo-file-system used by components/tests
 jest.mock(

--- a/src/hooks/useOfflineData.ts
+++ b/src/hooks/useOfflineData.ts
@@ -1,12 +1,22 @@
-import { useState, useEffect, useCallback } from 'react';
-import { offlineStorage } from '../services/offlineStorage';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+
 import { useNetworkStatus } from './useNetworkStatus';
-import logger from '../utils/logger';
+import { offlineStorage } from '../services/offlineStorage';
+import { syncService } from '../services/syncService';
+import { logger } from '../utils/logger';
 
-// Data sync status
+import type { SyncConflictResolutionStrategy, SyncOperationType } from '../services/offlineStorage';
+import type { SyncStats } from '../services/syncService';
+
 export type DataSyncStatus = 'synced' | 'pending' | 'conflict' | 'error';
+export type OfflineConflictResolutionStrategy =
+  | SyncConflictResolutionStrategy
+  | 'serverWins'
+  | 'clientWins'
+  | 'merge';
 
-// Offline data item interface
+type MutationOperationType = Exclude<SyncOperationType, 'READ'>;
+
 export interface OfflineDataItem<T> {
   id: string;
   data: T;
@@ -14,44 +24,121 @@ export interface OfflineDataItem<T> {
   lastModified: number;
   syncAttempts: number;
   errorMessage?: string;
+  version?: number;
+  baseData?: T;
+  serverData?: T;
+  operation?: MutationOperationType;
+  deleted?: boolean;
+  conflictResolutionStrategy?: SyncConflictResolutionStrategy;
 }
 
-// Hook options
-interface UseOfflineDataOptions {
+export interface UseOfflineDataOptions<T = unknown> {
   autoSync?: boolean;
   maxSyncAttempts?: number;
-  conflictResolutionStrategy?: 'serverWins' | 'clientWins' | 'merge';
+  conflictResolutionStrategy?: OfflineConflictResolutionStrategy;
+  endpointForItem?: (dataType: string, id: string, item?: OfflineDataItem<T>) => string;
+}
+
+const defaultSyncStats: SyncStats = {
+  pendingCount: 0,
+  failedCount: 0,
+  isSyncing: false,
+  successCount: 0,
+  failureCount: 0,
+  conflictCount: 0,
+  successRate: 1,
+};
+
+function normalizeConflictStrategy(
+  strategy: OfflineConflictResolutionStrategy
+): SyncConflictResolutionStrategy {
+  if (strategy === 'serverWins') return 'server-wins';
+  if (strategy === 'clientWins') return 'client-wins';
+  if (strategy === 'merge') return 'manual';
+  return strategy;
+}
+
+function mergeItemData<T>(currentData: T, patchData: Partial<T>): T {
+  if (
+    currentData !== null &&
+    typeof currentData === 'object' &&
+    patchData !== null &&
+    typeof patchData === 'object'
+  ) {
+    return {
+      ...(currentData as Record<string, unknown>),
+      ...(patchData as Record<string, unknown>),
+    } as T;
+  }
+
+  return patchData as T;
+}
+
+function normalizeStoredData<T>(
+  storedData: Record<string, OfflineDataItem<T>> | null
+): Record<string, OfflineDataItem<T>> {
+  if (!storedData) return {};
+
+  return Object.entries(storedData).reduce<Record<string, OfflineDataItem<T>>>(
+    (normalized, [id, item]) => {
+      normalized[id] = {
+        ...item,
+        id: item.id ?? id,
+        status: item.status ?? 'synced',
+        lastModified: item.lastModified ?? Date.now(),
+        syncAttempts: item.syncAttempts ?? 0,
+        version: item.version ?? 1,
+        deleted: item.deleted ?? false,
+      };
+      return normalized;
+    },
+    {}
+  );
+}
+
+function defaultEndpointForItem(dataType: string, id: string): string {
+  return `/${dataType}/${id}`;
 }
 
 /**
- * Hook for managing offline data with automatic synchronization
+ * Hook for persisted offline-first data with queued mutations and conflict resolution.
  */
-export function useOfflineData<T>(
-  dataType: string,
-  options: UseOfflineDataOptions = {}
-) {
+export function useOfflineData<T>(dataType: string, options: UseOfflineDataOptions<T> = {}) {
   const {
     autoSync = true,
     maxSyncAttempts = 3,
-    conflictResolutionStrategy = 'serverWins'
+    conflictResolutionStrategy = 'server-wins',
+    endpointForItem = defaultEndpointForItem,
   } = options;
+
+  const defaultConflictStrategy = useMemo(
+    () => normalizeConflictStrategy(conflictResolutionStrategy),
+    [conflictResolutionStrategy]
+  );
 
   const [data, setData] = useState<Record<string, OfflineDataItem<T>>>({});
   const [isLoading, setIsLoading] = useState(true);
   const [isSyncing, setIsSyncing] = useState(false);
+  const [syncStats, setSyncStats] = useState<SyncStats>(defaultSyncStats);
+  const syncStartedForConnection = useRef(false);
   const { isOnline, refresh: refreshNetworkStatus } = useNetworkStatus();
 
-  // Load data from offline storage
+  const refreshSyncStats = useCallback(async () => {
+    try {
+      const stats = await syncService.getSyncStats();
+      setSyncStats(stats);
+    } catch (error) {
+      logger.error('Error loading sync stats:', error);
+    }
+  }, []);
+
   const loadData = useCallback(async () => {
     try {
       setIsLoading(true);
-      const storedData = await offlineStorage.retrieve<Record<string, OfflineDataItem<T>>>(dataType);
-      
-      if (storedData) {
-        setData(storedData);
-      } else {
-        setData({});
-      }
+      const storedData =
+        await offlineStorage.retrieve<Record<string, OfflineDataItem<T>>>(dataType);
+
+      setData(normalizeStoredData(storedData));
     } catch (error) {
       logger.error(`Error loading ${dataType} data:`, error);
       setData({});
@@ -60,247 +147,363 @@ export function useOfflineData<T>(
     }
   }, [dataType]);
 
-  // Save data to offline storage
-  const saveData = useCallback(async (newData: Record<string, OfflineDataItem<T>>) => {
-    try {
-      await offlineStorage.store(dataType, newData);
-      setData(newData);
-    } catch (error) {
-      logger.error(`Error saving ${dataType} data:`, error);
-      throw error;
-    }
-  }, [dataType]);
-
-  // Add new item
-  const addItem = useCallback(async (id: string, itemData: T): Promise<void> => {
-    try {
-      const newItem: OfflineDataItem<T> = {
-        id,
-        data: itemData,
-        status: 'pending',
-        lastModified: Date.now(),
-        syncAttempts: 0,
-      };
-
-      const updatedData = {
-        ...data,
-        [id]: newItem
-      };
-
-      await saveData(updatedData);
-      
-      // Add to sync queue if online
-      if (isOnline) {
-        await offlineStorage.addToSyncQueue({
-          type: 'CREATE',
-          endpoint: `/${dataType}/${id}`,
-          data: itemData,
-          priority: 'high'
-        });
+  const saveData = useCallback(
+    async (newData: Record<string, OfflineDataItem<T>>) => {
+      try {
+        await offlineStorage.store(dataType, newData);
+        setData(newData);
+      } catch (error) {
+        logger.error(`Error saving ${dataType} data:`, error);
+        throw error;
       }
-    } catch (error) {
-      logger.error(`Error adding ${dataType} item:`, error);
-      throw error;
-    }
-  }, [data, dataType, isOnline, saveData]);
+    },
+    [dataType]
+  );
 
-  // Update existing item
-  const updateItem = useCallback(async (id: string, itemData: Partial<T>): Promise<void> => {
-    try {
-      const existingItem = data[id];
-      if (!existingItem) {
-        throw new Error(`Item with id ${id} not found`);
-      }
+  const getEndpoint = useCallback(
+    (id: string, item?: OfflineDataItem<T>) => endpointForItem(dataType, id, item),
+    [dataType, endpointForItem]
+  );
 
-      const updatedItem: OfflineDataItem<T> = {
-        ...existingItem,
-        data: { ...existingItem.data, ...itemData },
-        status: 'pending',
-        lastModified: Date.now(),
-        syncAttempts: 0,
-      };
-
-      const updatedData = {
-        ...data,
-        [id]: updatedItem
-      };
-
-      await saveData(updatedData);
-      
-      // Add to sync queue if online
-      if (isOnline) {
-        await offlineStorage.addToSyncQueue({
-          type: 'UPDATE',
-          endpoint: `/${dataType}/${id}`,
-          data: updatedItem.data,
-          priority: 'medium'
-        });
-      }
-    } catch (error) {
-      logger.error(`Error updating ${dataType} item:`, error);
-      throw error;
-    }
-  }, [data, dataType, isOnline, saveData]);
-
-  // Delete item
-  const deleteItem = useCallback(async (id: string): Promise<void> => {
-    try {
-      const updatedData = { ...data };
-      delete updatedData[id];
-
-      await saveData(updatedData);
-      
-      // Add to sync queue if online
-      if (isOnline) {
-        await offlineStorage.addToSyncQueue({
-          type: 'DELETE',
-          endpoint: `/${dataType}/${id}`,
-          priority: 'medium'
-        });
-      }
-    } catch (error) {
-      logger.error(`Error deleting ${dataType} item:`, error);
-      throw error;
-    }
-  }, [data, dataType, isOnline, saveData]);
-
-  // Get item by ID
-  const getItem = useCallback((id: string): T | null => {
-    const item = data[id];
-    return item ? item.data : null;
-  }, [data]);
-
-  // Get items with specific status
-  const getItemsByStatus = useCallback((status: DataSyncStatus): T[] => {
-    return Object.values(data)
-      .filter(item => item.status === status)
-      .map(item => item.data);
-  }, [data]);
-
-  // Sync specific item
-  const syncItem = useCallback(async (id: string): Promise<void> => {
-    const item = data[id];
-    if (!item) return;
-
-    try {
-      setIsSyncing(true);
-      
-      // Add to sync queue
+  const queueMutation = useCallback(
+    async (item: OfflineDataItem<T>, operation: MutationOperationType) => {
       await offlineStorage.addToSyncQueue({
-        type: 'UPDATE',
-        endpoint: `/${dataType}/${id}`,
-        data: item.data,
-        priority: 'high'
+        type: operation,
+        endpoint: getEndpoint(item.id, item),
+        data: operation === 'DELETE' ? undefined : item.data,
+        priority: operation === 'CREATE' ? 'high' : 'medium',
+        localVersion: item.version,
+        lastModified: item.lastModified,
+        baseData: item.baseData,
+        conflictStrategy: item.conflictResolutionStrategy ?? defaultConflictStrategy,
       });
+    },
+    [defaultConflictStrategy, getEndpoint]
+  );
 
-      // Update local status
-      const updatedItem: OfflineDataItem<T> = {
-        ...item,
-        status: 'pending',
-        syncAttempts: item.syncAttempts + 1
-      };
+  const flushIfOnline = useCallback(async () => {
+    if (!autoSync || !isOnline) return;
 
-      const updatedData = {
-        ...data,
-        [id]: updatedItem
-      };
-
-      await saveData(updatedData);
+    try {
+      await syncService.manualSync();
+      await refreshSyncStats();
     } catch (error) {
-      logger.error(`Error syncing ${dataType} item ${id}:`, error);
-      
-      // Update error status
-      const errorItem: OfflineDataItem<T> = {
-        ...item,
-        status: 'error',
-        errorMessage: error instanceof Error ? error.message : 'Unknown error',
-        syncAttempts: item.syncAttempts + 1
-      };
-
-      const updatedData = {
-        ...data,
-        [id]: errorItem
-      };
-
-      await saveData(updatedData);
-      throw error;
-    } finally {
-      setIsSyncing(false);
+      logger.error('Error flushing offline queue:', error);
     }
-  }, [data, dataType, saveData]);
+  }, [autoSync, isOnline, refreshSyncStats]);
 
-  // Sync all pending items
+  const addItem = useCallback(
+    async (id: string, itemData: T): Promise<void> => {
+      try {
+        const now = Date.now();
+        const newItem: OfflineDataItem<T> = {
+          id,
+          data: itemData,
+          status: 'pending',
+          lastModified: now,
+          syncAttempts: 0,
+          version: 1,
+          operation: 'CREATE',
+          deleted: false,
+          conflictResolutionStrategy: defaultConflictStrategy,
+        };
+
+        const updatedData = {
+          ...data,
+          [id]: newItem,
+        };
+
+        await saveData(updatedData);
+        await queueMutation(newItem, 'CREATE');
+        await flushIfOnline();
+      } catch (error) {
+        logger.error(`Error adding ${dataType} item:`, error);
+        throw error;
+      }
+    },
+    [data, dataType, defaultConflictStrategy, flushIfOnline, queueMutation, saveData]
+  );
+
+  const updateItem = useCallback(
+    async (id: string, itemData: Partial<T>): Promise<void> => {
+      try {
+        const existingItem = data[id];
+        if (!existingItem || existingItem.deleted) {
+          throw new Error(`Item with id ${id} not found`);
+        }
+
+        const nextOperation: MutationOperationType =
+          existingItem.operation === 'CREATE' ? 'CREATE' : 'UPDATE';
+        const updatedItem: OfflineDataItem<T> = {
+          ...existingItem,
+          data: mergeItemData(existingItem.data, itemData),
+          status: 'pending',
+          lastModified: Date.now(),
+          syncAttempts: 0,
+          errorMessage: undefined,
+          version: (existingItem.version ?? 1) + 1,
+          baseData: existingItem.baseData ?? existingItem.data,
+          operation: nextOperation,
+          deleted: false,
+          conflictResolutionStrategy:
+            existingItem.conflictResolutionStrategy ?? defaultConflictStrategy,
+        };
+
+        const updatedData = {
+          ...data,
+          [id]: updatedItem,
+        };
+
+        await saveData(updatedData);
+        await queueMutation(updatedItem, nextOperation);
+        await flushIfOnline();
+      } catch (error) {
+        logger.error(`Error updating ${dataType} item:`, error);
+        throw error;
+      }
+    },
+    [data, dataType, defaultConflictStrategy, flushIfOnline, queueMutation, saveData]
+  );
+
+  const deleteItem = useCallback(
+    async (id: string): Promise<void> => {
+      try {
+        const existingItem = data[id];
+        if (!existingItem) return;
+
+        const deletedItem: OfflineDataItem<T> = {
+          ...existingItem,
+          status: 'pending',
+          lastModified: Date.now(),
+          syncAttempts: 0,
+          errorMessage: undefined,
+          version: (existingItem.version ?? 1) + 1,
+          baseData: existingItem.baseData ?? existingItem.data,
+          operation: 'DELETE',
+          deleted: true,
+          conflictResolutionStrategy:
+            existingItem.conflictResolutionStrategy ?? defaultConflictStrategy,
+        };
+
+        const updatedData = {
+          ...data,
+          [id]: deletedItem,
+        };
+
+        await saveData(updatedData);
+        await queueMutation(deletedItem, 'DELETE');
+        await flushIfOnline();
+      } catch (error) {
+        logger.error(`Error deleting ${dataType} item:`, error);
+        throw error;
+      }
+    },
+    [data, dataType, defaultConflictStrategy, flushIfOnline, queueMutation, saveData]
+  );
+
+  const getItem = useCallback(
+    (id: string): T | null => {
+      const item = data[id];
+      return item && !item.deleted ? item.data : null;
+    },
+    [data]
+  );
+
+  const getRecordsByStatus = useCallback(
+    (status: DataSyncStatus): OfflineDataItem<T>[] =>
+      Object.values(data).filter(item => item.status === status),
+    [data]
+  );
+
+  const getItemsByStatus = useCallback(
+    (status: DataSyncStatus): T[] =>
+      getRecordsByStatus(status)
+        .filter(item => !item.deleted)
+        .map(item => item.data),
+    [getRecordsByStatus]
+  );
+
+  const syncItem = useCallback(
+    async (id: string): Promise<void> => {
+      const item = data[id];
+      if (!item) return;
+
+      try {
+        setIsSyncing(true);
+
+        const operation = item.operation ?? (item.deleted ? 'DELETE' : 'UPDATE');
+        await queueMutation(item, operation);
+
+        const updatedItem: OfflineDataItem<T> = {
+          ...item,
+          status: 'pending',
+          syncAttempts: item.syncAttempts + 1,
+          errorMessage: undefined,
+        };
+
+        const updatedData = {
+          ...data,
+          [id]: updatedItem,
+        };
+
+        await saveData(updatedData);
+        await flushIfOnline();
+      } catch (error) {
+        logger.error(`Error syncing ${dataType} item ${id}:`, error);
+
+        const errorItem: OfflineDataItem<T> = {
+          ...item,
+          status: 'error',
+          errorMessage: error instanceof Error ? error.message : 'Unknown error',
+          syncAttempts: item.syncAttempts + 1,
+        };
+
+        await saveData({
+          ...data,
+          [id]: errorItem,
+        });
+        throw error;
+      } finally {
+        setIsSyncing(false);
+      }
+    },
+    [data, dataType, flushIfOnline, queueMutation, saveData]
+  );
+
   const syncAll = useCallback(async (): Promise<void> => {
     try {
       setIsSyncing(true);
-      
-      const pendingItems = getItemsByStatus('pending');
-      const promises = pendingItems.map((_, index) => {
-        const id = Object.keys(data)[index];
-        return syncItem(id);
-      });
 
-      await Promise.all(promises);
+      const updatedData = { ...data };
+      const syncableItems = Object.values(data).filter(
+        item =>
+          (item.status === 'pending' || item.status === 'error') &&
+          item.syncAttempts < maxSyncAttempts
+      );
+
+      for (const item of syncableItems) {
+        const operation = item.operation ?? (item.deleted ? 'DELETE' : 'UPDATE');
+        await queueMutation(item, operation);
+        updatedData[item.id] = {
+          ...item,
+          status: 'pending',
+          syncAttempts: item.syncAttempts + 1,
+          errorMessage: undefined,
+        };
+      }
+
+      await saveData(updatedData);
+      await flushIfOnline();
     } catch (error) {
       logger.error(`Error syncing all ${dataType} items:`, error);
       throw error;
     } finally {
       setIsSyncing(false);
     }
-  }, [data, getItemsByStatus, syncItem]);
+  }, [data, dataType, flushIfOnline, maxSyncAttempts, queueMutation, saveData]);
 
-  // Mark item as synced
-  const markAsSynced = useCallback(async (id: string): Promise<void> => {
-    const item = data[id];
-    if (!item) return;
-
-    const updatedItem: OfflineDataItem<T> = {
-      ...item,
-      status: 'synced',
-      syncAttempts: 0,
-      errorMessage: undefined
-    };
-
-    const updatedData = {
-      ...data,
-      [id]: updatedItem
-    };
-
-    await saveData(updatedData);
-  }, [data, saveData]);
-
-  // Resolve conflict for item
-  const resolveConflict = useCallback(async (
-    id: string,
-    resolvedData: T,
-    strategy: 'serverWins' | 'clientWins' | 'merge' = conflictResolutionStrategy
-  ): Promise<void> => {
-    try {
+  const markAsSynced = useCallback(
+    async (id: string): Promise<void> => {
       const item = data[id];
       if (!item) return;
 
-      const resolvedItem: OfflineDataItem<T> = {
-        ...item,
-        data: resolvedData,
-        status: 'pending',
-        lastModified: Date.now(),
-        syncAttempts: 0,
-        errorMessage: undefined
-      };
-
-      const updatedData = {
-        ...data,
-        [id]: resolvedItem
-      };
+      const updatedData = { ...data };
+      if (item.deleted) {
+        delete updatedData[id];
+      } else {
+        updatedData[id] = {
+          ...item,
+          status: 'synced',
+          syncAttempts: 0,
+          errorMessage: undefined,
+          baseData: item.data,
+          serverData: undefined,
+          operation: undefined,
+          deleted: false,
+        };
+      }
 
       await saveData(updatedData);
-    } catch (error) {
-      logger.error(`Error resolving conflict for ${dataType} item ${id}:`, error);
-      throw error;
-    }
-  }, [data, dataType, conflictResolutionStrategy, saveData]);
+    },
+    [data, saveData]
+  );
 
-  // Clear all data
+  const markConflict = useCallback(
+    async (id: string, serverData: T, baseData?: T): Promise<void> => {
+      const item = data[id];
+      if (!item) return;
+
+      await saveData({
+        ...data,
+        [id]: {
+          ...item,
+          status: 'conflict',
+          serverData,
+          baseData: baseData ?? item.baseData ?? item.data,
+          errorMessage: 'Conflict detected during sync',
+          conflictResolutionStrategy: item.conflictResolutionStrategy ?? defaultConflictStrategy,
+        },
+      });
+    },
+    [data, defaultConflictStrategy, saveData]
+  );
+
+  const resolveConflict = useCallback(
+    async (
+      id: string,
+      resolvedData?: T,
+      strategy: OfflineConflictResolutionStrategy = conflictResolutionStrategy
+    ): Promise<void> => {
+      try {
+        const item = data[id];
+        if (!item) return;
+
+        const normalizedStrategy = normalizeConflictStrategy(strategy);
+        let nextData: T;
+
+        if (normalizedStrategy === 'server-wins') {
+          if (typeof item.serverData === 'undefined' && typeof resolvedData === 'undefined') {
+            throw new Error(`Server data is required to resolve conflict for ${id}`);
+          }
+          nextData = typeof item.serverData === 'undefined' ? (resolvedData as T) : item.serverData;
+        } else if (normalizedStrategy === 'client-wins') {
+          nextData = item.data;
+        } else {
+          if (typeof resolvedData === 'undefined') {
+            throw new Error(`Manual conflict resolution requires resolved data for ${id}`);
+          }
+          nextData = resolvedData;
+        }
+
+        const resolvedItem: OfflineDataItem<T> = {
+          ...item,
+          data: nextData,
+          status: 'pending',
+          lastModified: Date.now(),
+          syncAttempts: 0,
+          errorMessage: undefined,
+          version: (item.version ?? 1) + 1,
+          baseData: item.baseData ?? item.data,
+          serverData: undefined,
+          operation: 'UPDATE',
+          deleted: false,
+          conflictResolutionStrategy: normalizedStrategy,
+        };
+
+        await saveData({
+          ...data,
+          [id]: resolvedItem,
+        });
+        await queueMutation(resolvedItem, 'UPDATE');
+        await flushIfOnline();
+      } catch (error) {
+        logger.error(`Error resolving conflict for ${dataType} item ${id}:`, error);
+        throw error;
+      }
+    },
+    [conflictResolutionStrategy, data, dataType, flushIfOnline, queueMutation, saveData]
+  );
+
   const clearAll = useCallback(async (): Promise<void> => {
     try {
       await offlineStorage.remove(dataType);
@@ -311,60 +514,97 @@ export function useOfflineData<T>(
     }
   }, [dataType]);
 
-  // Refresh data from storage
   const refresh = useCallback(async (): Promise<void> => {
     await loadData();
     await refreshNetworkStatus();
-  }, [loadData, refreshNetworkStatus]);
+    await refreshSyncStats();
+  }, [loadData, refreshNetworkStatus, refreshSyncStats]);
 
-  // Auto-sync when coming online
+  const records = useMemo(() => Object.values(data), [data]);
+  const pendingRecords = useMemo(
+    () => records.filter(item => item.status === 'pending'),
+    [records]
+  );
+  const hasSyncableItems = useMemo(
+    () => records.some(item => item.status === 'pending' || item.status === 'error'),
+    [records]
+  );
+
   useEffect(() => {
-    if (autoSync && isOnline && Object.keys(data).length > 0) {
-      const pendingItems = getItemsByStatus('pending');
-      if (pendingItems.length > 0) {
-        syncAll().catch(error => {
-          logger.error('Auto-sync failed:', error);
-        });
+    const listener = (event: { type: string }) => {
+      if (
+        event.type === 'operationProcessed' ||
+        event.type === 'syncCompleted' ||
+        event.type === 'syncFailed' ||
+        event.type === 'conflictDetected'
+      ) {
+        void refreshSyncStats();
       }
-    }
-  }, [autoSync, isOnline, data, getItemsByStatus, syncAll]);
+    };
 
-  // Load data on mount
+    void refreshSyncStats();
+    syncService.addEventListener(listener);
+
+    return () => {
+      syncService.removeEventListener(listener);
+    };
+  }, [refreshSyncStats]);
+
+  useEffect(() => {
+    if (!isOnline) {
+      syncStartedForConnection.current = false;
+      return;
+    }
+
+    if (!autoSync || !hasSyncableItems || syncStartedForConnection.current) {
+      return;
+    }
+
+    syncStartedForConnection.current = true;
+    syncAll().catch(error => {
+      logger.error('Auto-sync failed:', error);
+    });
+  }, [autoSync, hasSyncableItems, isOnline, syncAll]);
+
   useEffect(() => {
     loadData();
   }, [loadData]);
 
   return {
-    // Data access
     data,
     getItem,
     getItemsByStatus,
-    
-    // CRUD operations
+    getRecordsByStatus,
+
     addItem,
     updateItem,
     deleteItem,
-    
-    // Sync operations
+
     syncItem,
     syncAll,
     markAsSynced,
+    markConflict,
     resolveConflict,
-    
-    // Status
+
     isLoading,
     isSyncing,
     isOnline,
-    
-    // Management
+
     clearAll,
     refresh,
-    
-    // Stats
-    totalCount: Object.keys(data).length,
-    pendingCount: getItemsByStatus('pending').length,
-    syncedCount: getItemsByStatus('synced').length,
-    errorCount: getItemsByStatus('error').length,
+    refreshSyncStats,
+
+    totalCount: records.filter(item => !item.deleted).length,
+    pendingCount: pendingRecords.length,
+    syncedCount: records.filter(item => item.status === 'synced' && !item.deleted).length,
+    conflictCount: records.filter(item => item.status === 'conflict').length,
+    errorCount: records.filter(item => item.status === 'error').length,
+    deletedCount: records.filter(item => item.deleted).length,
+    syncSuccessRate: syncStats.successRate,
+    syncSuccessCount: syncStats.successCount,
+    syncFailureCount: syncStats.failureCount,
+    syncConflictCount: syncStats.conflictCount,
+    lastSyncTime: syncStats.lastSyncTime,
   };
 }
 
@@ -374,7 +614,7 @@ export function useOfflineData<T>(
 export function useOfflineCourses() {
   return useOfflineData<any>('courses', {
     autoSync: true,
-    conflictResolutionStrategy: 'serverWins'
+    conflictResolutionStrategy: 'server-wins',
   });
 }
 
@@ -384,7 +624,7 @@ export function useOfflineCourses() {
 export function useOfflineUserData() {
   return useOfflineData<any>('userData', {
     autoSync: true,
-    conflictResolutionStrategy: 'clientWins'
+    conflictResolutionStrategy: 'client-wins',
   });
 }
 
@@ -393,8 +633,8 @@ export function useOfflineUserData() {
  */
 export function useOfflineSettings() {
   return useOfflineData<any>('settings', {
-    autoSync: false, // Settings typically don't need server sync
-    conflictResolutionStrategy: 'clientWins'
+    autoSync: false,
+    conflictResolutionStrategy: 'client-wins',
   });
 }
 

--- a/src/services/offlineStorage.ts
+++ b/src/services/offlineStorage.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import logger from '../utils/logger';
+
+import { logger } from '../utils/logger';
 
 // Storage keys
 const STORAGE_KEYS = {
@@ -21,6 +22,7 @@ interface StorageItem<T> {
 
 // Sync operation types
 export type SyncOperationType = 'CREATE' | 'UPDATE' | 'DELETE' | 'READ';
+export type SyncConflictResolutionStrategy = 'server-wins' | 'client-wins' | 'manual';
 
 // Sync operation interface
 export interface SyncOperation {
@@ -28,6 +30,10 @@ export interface SyncOperation {
   type: SyncOperationType;
   endpoint: string;
   data?: any;
+  localVersion?: number;
+  lastModified?: number;
+  baseData?: any;
+  conflictStrategy?: SyncConflictResolutionStrategy;
   timestamp: number;
   retries: number;
   maxRetries: number;
@@ -66,7 +72,7 @@ class OfflineStorage {
     try {
       const itemStr = await AsyncStorage.getItem(key);
       if (!itemStr) return null;
-      
+
       const item: StorageItem<T> = JSON.parse(itemStr);
       return item.data;
     } catch (error) {
@@ -121,14 +127,14 @@ class OfflineStorage {
     try {
       const keys = await AsyncStorage.getAllKeys();
       let totalSize = 0;
-      
+
       for (const key of keys) {
         const value = await AsyncStorage.getItem(key);
         if (value) {
           totalSize += value.length;
         }
       }
-      
+
       return totalSize;
     } catch (error) {
       logger.error('Error getting storage size:', error);
@@ -152,7 +158,7 @@ class OfflineStorage {
     try {
       const keys = await AsyncStorage.getAllKeys();
       const courseKeys = keys.filter(key => key.startsWith(STORAGE_KEYS.COURSE_DATA));
-      
+
       const courses = [];
       for (const key of courseKeys) {
         const course = await this.retrieve(key);
@@ -160,7 +166,7 @@ class OfflineStorage {
           courses.push(course);
         }
       }
-      
+
       return courses;
     } catch (error) {
       logger.error('Error getting all courses:', error);
@@ -211,17 +217,27 @@ class OfflineStorage {
   async addToSyncQueue(operation: SyncOperationInput): Promise<string> {
     try {
       const queue = await this.getSyncQueue();
-      
+      const existingIndex = queue.findIndex(
+        op =>
+          op.endpoint === operation.endpoint &&
+          op.type === operation.type &&
+          op.retries < op.maxRetries
+      );
+
       const syncOp: SyncOperation = {
-        id: this.generateOperationId(),
+        id: existingIndex >= 0 ? queue[existingIndex].id : this.generateOperationId(),
         ...operation,
         timestamp: Date.now(),
         retries: 0,
         maxRetries: this.MAX_RETRIES,
       };
 
-      queue.push(syncOp);
-      
+      if (existingIndex >= 0) {
+        queue[existingIndex] = syncOp;
+      } else {
+        queue.push(syncOp);
+      }
+
       // Sort by priority and timestamp
       queue.sort((a, b) => {
         const priorityOrder = { high: 0, medium: 1, low: 2 };
@@ -232,8 +248,8 @@ class OfflineStorage {
       });
 
       await this.store(STORAGE_KEYS.SYNC_QUEUE, queue);
-      logger.info(`Added operation to sync queue: ${syncOp.type} ${syncOp.endpoint}`);
-      
+      logger.info(`Queued operation for sync: ${syncOp.type} ${syncOp.endpoint}`);
+
       return syncOp.id;
     } catch (error) {
       logger.error('Error adding to sync queue:', error);
@@ -261,7 +277,7 @@ class OfflineStorage {
     try {
       const queue = await this.getSyncQueue();
       const operation = queue.find(op => op.id === operationId);
-      
+
       if (operation) {
         operation.retries += 1;
         await this.store(STORAGE_KEYS.SYNC_QUEUE, queue);

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -1,18 +1,17 @@
 import * as Network from 'expo-network';
 
-import apiService from './api';
-import batchClient from './api/batchClient';
+import { apiService } from './api';
+import { batchClient } from './api/batchClient';
 import { offlineStorage, SyncOperation, SyncOperationType } from './offlineStorage';
-import syncEntityManager from './sync/syncEntityManager';
-import { useSettingsStore } from '../store/settingsStore';
+import { syncEntityManager } from './sync/syncEntityManager';
 import { useDeviceStore } from '../store/deviceStore';
-import logger from '../utils/logger';
+import { useSettingsStore } from '../store/settingsStore';
+import { logger } from '../utils/logger';
 
 import type {
-    ConflictResolutionStrategy as VersionedConflictResolutionStrategy,
-    VersionedEntity,
+  ConflictResolutionStrategy as VersionedConflictResolutionStrategy,
+  VersionedEntity,
 } from './sync/types';
-
 
 // Sync service configuration
 interface SyncConfig {
@@ -46,11 +45,29 @@ interface SyncEvent {
   timestamp: number;
 }
 
+export interface SyncStats {
+  pendingCount: number;
+  failedCount: number;
+  isSyncing: boolean;
+  lastSyncTime?: number;
+  successCount: number;
+  failureCount: number;
+  conflictCount: number;
+  successRate: number;
+}
+
 class SyncService {
   private isSyncing: boolean = false;
   private syncIntervalId: any = null;
   private eventListeners: ((event: SyncEvent) => void)[] = [];
   private config: SyncConfig;
+  private metrics = {
+    attemptedOperations: 0,
+    successfulOperations: 0,
+    failedOperations: 0,
+    conflictsDetected: 0,
+    lastSyncTime: undefined as number | undefined,
+  };
 
   constructor(config?: Partial<SyncConfig>) {
     this.config = {
@@ -62,17 +79,17 @@ class SyncService {
     };
 
     // Subscribe to battery status changes to adjust sync frequency
-    useDeviceStore.subscribe(
-      (state: any, prevState: any) => {
-        if (state.isLowBattery !== prevState.isLowBattery) {
-          logger.info(`SyncService: Low battery status changed to ${state.isLowBattery}, restarting auto-sync`);
-          if (this.syncIntervalId) {
-            this.stopAutoSync();
-            this.startAutoSync();
-          }
+    useDeviceStore.subscribe((state: any, prevState: any) => {
+      if (state.isLowBattery !== prevState.isLowBattery) {
+        logger.info(
+          `SyncService: Low battery status changed to ${state.isLowBattery}, restarting auto-sync`
+        );
+        if (this.syncIntervalId) {
+          this.stopAutoSync();
+          this.startAutoSync();
         }
       }
-    );
+    });
   }
 
   /**
@@ -153,11 +170,12 @@ class SyncService {
         return;
       }
 
+      this.metrics.attemptedOperations += queue.length;
       logger.info(`Starting sync for ${queue.length} operations`);
 
       // Process operations in batches
       const batches = this.createBatches(queue, this.config.batchSize);
-      
+
       for (const batch of batches) {
         await this.processBatch(batch);
       }
@@ -166,10 +184,10 @@ class SyncService {
       this.emitEvent({ type: 'syncCompleted', timestamp: Date.now() });
     } catch (error) {
       logger.error('Sync failed:', error);
-      this.emitEvent({ 
-        type: 'syncFailed', 
-        error, 
-        timestamp: Date.now() 
+      this.emitEvent({
+        type: 'syncFailed',
+        error,
+        timestamp: Date.now(),
       });
     } finally {
       this.isSyncing = false;
@@ -194,6 +212,7 @@ class SyncService {
         .mutate(method, op.endpoint, op.data)
         .then(async result => {
           await offlineStorage.removeFromSyncQueue(op.id);
+          this.recordSyncSuccess();
           logger.info(`Batch operation completed: ${op.id}`);
           this.emitEvent({
             type: 'operationProcessed',
@@ -204,14 +223,12 @@ class SyncService {
         })
         .catch(async (error: any) => {
           logger.error(`Batch operation failed: ${op.id}`, error);
+          this.recordSyncFailure(op, error);
           if (op.retries < op.maxRetries) {
             await offlineStorage.incrementRetryCount(op.id);
-            setTimeout(
-              () => this.retryOperation(op.id),
-              this.calculateRetryDelay(op.retries),
-            );
+            setTimeout(() => this.retryOperation(op.id), this.calculateRetryDelay(op.retries));
           } else {
-            this.handlePermanentFailure(op, error);
+            await this.handlePermanentFailure(op, error);
           }
           this.emitEvent({
             type: 'syncFailed',
@@ -226,9 +243,7 @@ class SyncService {
     await Promise.all([batchClient.flush(), ...mutationPromises, ...readPromises]);
   }
 
-  private mapOperationToMethod(
-    type: SyncOperationType,
-  ): 'POST' | 'PUT' | 'DELETE' | null {
+  private mapOperationToMethod(type: SyncOperationType): 'POST' | 'PUT' | 'DELETE' | null {
     if (type === 'CREATE') return 'POST';
     if (type === 'UPDATE') return 'PUT';
     if (type === 'DELETE') return 'DELETE';
@@ -263,37 +278,40 @@ class SyncService {
 
       // Remove successful operation from queue
       await offlineStorage.removeFromSyncQueue(operation.id);
-      
+      this.recordSyncSuccess();
+
       logger.info(`Operation completed: ${operation.id}`);
       this.emitEvent({
         type: 'operationProcessed',
         operationId: operation.id,
         data: result,
-        timestamp: Date.now()
+        timestamp: Date.now(),
       });
-
     } catch (error: any) {
       logger.error(`Operation failed: ${operation.id}`, error);
+      this.recordSyncFailure(operation, error);
 
       // Handle retry logic
       if (operation.retries < operation.maxRetries) {
         await offlineStorage.incrementRetryCount(operation.id);
-        
+
         // Schedule retry with exponential backoff
         setTimeout(() => {
           this.retryOperation(operation.id);
         }, this.calculateRetryDelay(operation.retries));
       } else {
-        logger.error(`Operation failed permanently after ${operation.maxRetries} retries: ${operation.id}`);
+        logger.error(
+          `Operation failed permanently after ${operation.maxRetries} retries: ${operation.id}`
+        );
         // Move to failed operations for manual handling
-        this.handlePermanentFailure(operation, error);
+        await this.handlePermanentFailure(operation, error);
       }
 
       this.emitEvent({
         type: 'syncFailed',
         operationId: operation.id,
         error,
-        timestamp: Date.now()
+        timestamp: Date.now(),
       });
     }
   }
@@ -304,7 +322,7 @@ class SyncService {
   private async retryOperation(operationId: string): Promise<void> {
     const queue = await offlineStorage.getSyncQueue();
     const operation = queue.find(op => op.id === operationId);
-    
+
     if (operation) {
       await this.processOperation(operation);
     }
@@ -318,7 +336,7 @@ class SyncService {
     logger.error('Permanent sync failure:', {
       operation,
       error: error.message,
-      timestamp: Date.now()
+      timestamp: Date.now(),
     });
 
     // Could implement notification system here
@@ -354,6 +372,38 @@ class SyncService {
    */
   private calculateRetryDelay(retryCount: number): number {
     return this.config.retryDelay * Math.pow(2, retryCount);
+  }
+
+  private recordSyncSuccess(): void {
+    this.metrics.successfulOperations += 1;
+    this.metrics.lastSyncTime = Date.now();
+  }
+
+  private recordSyncFailure(operation: SyncOperation, error: any): void {
+    this.metrics.failedOperations += 1;
+
+    if (this.isConflictError(error)) {
+      this.metrics.conflictsDetected += 1;
+      this.emitEvent({
+        type: 'conflictDetected',
+        operationId: operation.id,
+        data: {
+          operation,
+          serverData: this.extractConflictPayload(error),
+          strategy: operation.conflictStrategy ?? 'server-wins',
+        },
+        error,
+        timestamp: Date.now(),
+      });
+    }
+  }
+
+  private isConflictError(error: any): boolean {
+    return error?.status === 409 || error?.response?.status === 409 || error?.code === 'CONFLICT';
+  }
+
+  private extractConflictPayload(error: any): any {
+    return error?.response?.data ?? error?.data ?? error?.body ?? null;
   }
 
   /**
@@ -396,20 +446,20 @@ class SyncService {
   /**
    * Get sync statistics
    */
-  async getSyncStats(): Promise<{
-    pendingCount: number;
-    failedCount: number;
-    isSyncing: boolean;
-    lastSyncTime?: number;
-  }> {
+  async getSyncStats(): Promise<SyncStats> {
     const pendingCount = await offlineStorage.getPendingOperationsCount();
     const failedOperations = await offlineStorage.getFailedOperations();
-    
+    const processedCount = this.metrics.successfulOperations + this.metrics.failedOperations;
+
     return {
       pendingCount,
       failedCount: failedOperations.length,
       isSyncing: this.isSyncing,
-      // Could store last sync time in AsyncStorage if needed
+      lastSyncTime: this.metrics.lastSyncTime,
+      successCount: this.metrics.successfulOperations,
+      failureCount: this.metrics.failedOperations,
+      conflictCount: this.metrics.conflictsDetected,
+      successRate: processedCount === 0 ? 1 : this.metrics.successfulOperations / processedCount,
     };
   }
 
@@ -420,14 +470,15 @@ class SyncService {
     localData: any,
     serverData: any,
     strategy: ConflictResolutionStrategy = 'server-wins',
-    baseData?: any,
+    baseData?: any
   ): Promise<any> {
     const normalizedStrategy = this.normalizeConflictStrategy(strategy);
+    this.metrics.conflictsDetected += 1;
 
     this.emitEvent({
       type: 'conflictDetected',
       data: { localData, serverData, strategy: normalizedStrategy },
-      timestamp: Date.now()
+      timestamp: Date.now(),
     });
 
     if (strategy === 'manual') {
@@ -438,13 +489,13 @@ class SyncService {
       localData,
       serverData,
       normalizedStrategy,
-      baseData,
+      baseData
     );
 
     this.emitEvent({
       type: 'conflictResolved',
       data: result,
-      timestamp: Date.now()
+      timestamp: Date.now(),
     });
 
     return result.resolved.data;
@@ -456,14 +507,14 @@ class SyncService {
   resolveVersionedConflict<T extends Record<string, unknown>>(
     serverEntity: VersionedEntity<T>,
     strategy: ConflictResolutionStrategy = 'merge',
-    baseEntity?: VersionedEntity<T>,
+    baseEntity?: VersionedEntity<T>
   ) {
     const normalizedStrategy = this.normalizeConflictStrategy(strategy);
     return syncEntityManager.handleServerEntity(serverEntity, normalizedStrategy, baseEntity);
   }
 
   private normalizeConflictStrategy(
-    strategy: ConflictResolutionStrategy,
+    strategy: ConflictResolutionStrategy
   ): VersionedConflictResolutionStrategy {
     switch (strategy) {
       case 'serverWins':

--- a/tests/hooks/useOfflineData.test.ts
+++ b/tests/hooks/useOfflineData.test.ts
@@ -1,0 +1,257 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import { useOfflineData } from '../../src/hooks/useOfflineData';
+import { offlineStorage } from '../../src/services/offlineStorage';
+import { syncService } from '../../src/services/syncService';
+
+import type { OfflineDataItem } from '../../src/hooks/useOfflineData';
+
+type Course = { title: string };
+
+const mockRefreshNetworkStatus = jest.fn();
+let mockIsOnline = false;
+
+const mockSyncStats = {
+  pendingCount: 0,
+  failedCount: 0,
+  isSyncing: false,
+  successCount: 0,
+  failureCount: 0,
+  conflictCount: 0,
+  successRate: 1,
+};
+
+jest.mock('../../src/hooks/useNetworkStatus', () => ({
+  useNetworkStatus: () => ({
+    isOnline: mockIsOnline,
+    refresh: mockRefreshNetworkStatus,
+  }),
+}));
+
+jest.mock('../../src/services/offlineStorage', () => ({
+  offlineStorage: {
+    retrieve: jest.fn(),
+    store: jest.fn(),
+    addToSyncQueue: jest.fn(),
+    remove: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/services/syncService', () => ({
+  __esModule: true,
+  syncService: {
+    getSyncStats: jest.fn(),
+    manualSync: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/utils/logger', () => {
+  const mockLogger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+  return {
+    __esModule: true,
+    logger: mockLogger,
+    default: mockLogger,
+  };
+});
+
+const mockRetrieve = offlineStorage.retrieve as jest.Mock;
+const mockStore = offlineStorage.store as jest.Mock;
+const mockAddToSyncQueue = offlineStorage.addToSyncQueue as jest.Mock;
+const mockManualSync = syncService.manualSync as jest.Mock;
+const mockGetSyncStats = syncService.getSyncStats as jest.Mock;
+
+function storedCourse(
+  id: string,
+  data: Course,
+  overrides: Partial<OfflineDataItem<Course>> = {}
+): OfflineDataItem<Course> {
+  return {
+    id,
+    data,
+    status: 'synced',
+    lastModified: 1000,
+    syncAttempts: 0,
+    version: 1,
+    ...overrides,
+  };
+}
+
+describe('useOfflineData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsOnline = false;
+    mockRetrieve.mockResolvedValue(null);
+    mockStore.mockResolvedValue(undefined);
+    mockAddToSyncQueue.mockResolvedValue('op-1');
+    mockManualSync.mockResolvedValue(undefined);
+    mockGetSyncStats.mockResolvedValue(mockSyncStats);
+  });
+
+  it('persists and queues create mutations while offline', async () => {
+    const { result } = renderHook(() => useOfflineData<Course>('courses', { autoSync: false }));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.addItem('course-1', { title: 'Offline draft' });
+    });
+
+    expect(result.current.getItem('course-1')).toEqual({ title: 'Offline draft' });
+    expect(result.current.pendingCount).toBe(1);
+    expect(mockStore).toHaveBeenLastCalledWith(
+      'courses',
+      expect.objectContaining({
+        'course-1': expect.objectContaining({
+          status: 'pending',
+          operation: 'CREATE',
+          deleted: false,
+        }),
+      })
+    );
+    expect(mockAddToSyncQueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'CREATE',
+        endpoint: '/courses/course-1',
+        data: { title: 'Offline draft' },
+        conflictStrategy: 'server-wins',
+      })
+    );
+    expect(mockManualSync).not.toHaveBeenCalled();
+  });
+
+  it('keeps deletes as pending tombstones until sync succeeds', async () => {
+    mockRetrieve.mockResolvedValue({
+      'course-1': storedCourse('course-1', { title: 'Saved course' }),
+    });
+
+    const { result } = renderHook(() => useOfflineData<Course>('courses', { autoSync: false }));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.deleteItem('course-1');
+    });
+
+    expect(result.current.getItem('course-1')).toBeNull();
+    expect(result.current.deletedCount).toBe(1);
+    expect(result.current.data['course-1']).toEqual(
+      expect.objectContaining({
+        status: 'pending',
+        operation: 'DELETE',
+        deleted: true,
+        data: { title: 'Saved course' },
+      })
+    );
+    expect(mockAddToSyncQueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'DELETE',
+        endpoint: '/courses/course-1',
+      })
+    );
+  });
+
+  it('resolves conflicts with server, client, and manual strategies', async () => {
+    mockRetrieve.mockResolvedValue({
+      server: storedCourse(
+        'server',
+        { title: 'Local server copy' },
+        {
+          status: 'conflict',
+          serverData: { title: 'Server copy' },
+        }
+      ),
+      client: storedCourse(
+        'client',
+        { title: 'Client copy' },
+        {
+          status: 'conflict',
+          serverData: { title: 'Ignored server copy' },
+        }
+      ),
+      manual: storedCourse(
+        'manual',
+        { title: 'Local manual copy' },
+        {
+          status: 'conflict',
+          serverData: { title: 'Server manual copy' },
+        }
+      ),
+    });
+
+    const { result } = renderHook(() => useOfflineData<Course>('courses', { autoSync: false }));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.resolveConflict('server', undefined, 'server-wins');
+    });
+    expect(result.current.getItem('server')).toEqual({ title: 'Server copy' });
+
+    await act(async () => {
+      await result.current.resolveConflict('client', undefined, 'client-wins');
+    });
+    expect(result.current.getItem('client')).toEqual({ title: 'Client copy' });
+
+    await act(async () => {
+      await result.current.resolveConflict('manual', { title: 'Merged copy' }, 'manual');
+    });
+    expect(result.current.getItem('manual')).toEqual({ title: 'Merged copy' });
+
+    expect(mockAddToSyncQueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'UPDATE',
+        endpoint: '/courses/server',
+        data: { title: 'Server copy' },
+        conflictStrategy: 'server-wins',
+      })
+    );
+    expect(mockAddToSyncQueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'UPDATE',
+        endpoint: '/courses/client',
+        data: { title: 'Client copy' },
+        conflictStrategy: 'client-wins',
+      })
+    );
+    expect(mockAddToSyncQueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'UPDATE',
+        endpoint: '/courses/manual',
+        data: { title: 'Merged copy' },
+        conflictStrategy: 'manual',
+      })
+    );
+  });
+
+  it('syncs pending records once when data loads on an online connection', async () => {
+    mockIsOnline = true;
+    mockRetrieve.mockResolvedValue({
+      'course-1': storedCourse(
+        'course-1',
+        { title: 'Pending course' },
+        {
+          status: 'pending',
+          operation: 'UPDATE',
+        }
+      ),
+    });
+
+    renderHook(() => useOfflineData<Course>('courses'));
+
+    await waitFor(() => expect(mockManualSync).toHaveBeenCalledTimes(1));
+    expect(mockAddToSyncQueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'UPDATE',
+        endpoint: '/courses/course-1',
+        data: { title: 'Pending course' },
+      })
+    );
+  });
+});

--- a/tests/services/syncService.test.ts
+++ b/tests/services/syncService.test.ts
@@ -5,10 +5,12 @@ import { syncService } from '../../src/services/syncService';
 import { useSettingsStore } from '../../src/store/settingsStore';
 
 jest.mock('expo-network', () => ({
-  getNetworkStateAsync: jest.fn(() => Promise.resolve({
-    isConnected: true,
-    isInternetReachable: true,
-  })),
+  getNetworkStateAsync: jest.fn(() =>
+    Promise.resolve({
+      isConnected: true,
+      isInternetReachable: true,
+    })
+  ),
 }));
 
 jest.mock('../../src/services/offlineStorage', () => ({
@@ -28,6 +30,7 @@ jest.mock('../../src/utils/logger', () => {
   };
   return {
     __esModule: true,
+    logger: mockLogger,
     default: mockLogger,
   };
 });


### PR DESCRIPTION
## Summary
- persist offline mutations immediately and queue create/update/delete operations regardless of connectivity
- keep deletes as tombstones until sync confirmation and add server-wins/client-wins/manual conflict resolution helpers
- add sync success/conflict metrics, focused hook coverage, and offline-first architecture docs

Closes #236

## Tests
- npx jest tests/hooks/useOfflineData.test.ts tests/services/syncService.test.ts --runInBand
- npx eslint src/hooks/useOfflineData.ts src/services/offlineStorage.ts src/services/syncService.ts tests/hooks/useOfflineData.test.ts tests/services/syncService.test.ts jest.setup.js --max-warnings=0
- git diff --check

## TypeScript
- npx tsc --noEmit is currently blocked by unrelated pre-existing syntax/type errors in files such as src/pages/mobile/MobileRegister.tsx, src/components/mobile/MobileQuizManager/QuizCarousel.tsx, src/services/index.ts, and existing logging/API/Sentry modules.