### PR TITLE
Fix search index debounce performance

### DIFF
--- a/src/components/mobile/MobileSearch.tsx
+++ b/src/components/mobile/MobileSearch.tsx
@@ -6,7 +6,7 @@ import { FilterField, FilterSheet, FilterValues } from './FilterSheet';
 import { SearchHistory } from './SearchHistory';
 import { SearchResultCard, SearchResultItem } from './SearchResultCard';
 import { VoiceSearch } from './VoiceSearch';
-import { useAnalytics, useDebounce, useDynamicFontSize, useMemoryMonitor } from '../../hooks';
+import { useAnalytics, useDynamicFontSize, useMemoryMonitor } from '../../hooks';
 import { usePrefetchImages } from '../../hooks/usePrefetchImages';
 import { useSearchIndex } from '../../hooks/useSearchIndex';
 import { addToSearchHistory } from '../../utils/searchHistory';
@@ -41,9 +41,21 @@ const DEFAULT_FILTERS: FilterField[] = [
 
 // Static fallback keywords used until the index-derived suggestions are ready.
 const FALLBACK_KEYWORDS = [
-  'React Native', 'Mobile Development', 'Expo', 'JavaScript', 'TypeScript',
-  'Web Development', 'Design', 'CSS', 'HTML', 'Node.js', 'Python',
-  'Machine Learning', 'beginner', 'intermediate', 'advanced',
+  'React Native',
+  'Mobile Development',
+  'Expo',
+  'JavaScript',
+  'TypeScript',
+  'Web Development',
+  'Design',
+  'CSS',
+  'HTML',
+  'Node.js',
+  'Python',
+  'Machine Learning',
+  'beginner',
+  'intermediate',
+  'advanced',
 ];
 
 export interface MobileSearchProps {
@@ -77,33 +89,32 @@ export const MobileSearch = ({
   const [filterValues, setFilterValues] = useState<FilterValues>({});
   const [results, setResults] = useState<SearchResultItem[]>([]);
   const [hasSearched, setHasSearched] = useState(false);
-  const [, setIsSearching] = useState(false);
-  const searchAbortRef = React.useRef<AbortController | null>(null);
 
   const fontSizeScale = useDynamicFontSize() as { scale?: (value: number) => number };
   const scale =
     typeof fontSizeScale.scale === 'function' ? fontSizeScale.scale : (value: number) => value;
   const { trackEvent } = useAnalytics();
 
-  const { search: indexSearch, suggestions: indexSuggestions, isReady: indexReady } =
-    useSearchIndex();
+  const {
+    search: indexSearch,
+    results: indexedResults,
+    debouncedQuery,
+    suggestions: indexSuggestions,
+    isReady: indexReady,
+  } = useSearchIndex({ query, filters: filterValues });
 
   useMemoryMonitor({ componentId: 'MobileSearch', itemCount: results.length });
 
   const resultThumbnails = useMemo(
     () => results.map((r: SearchResultItem) => r.thumbnail ?? null),
-    [results],
+    [results]
   );
   usePrefetchImages(resultThumbnails, { auto: true, limit: 10 });
-
-  const debouncedQuery = useDebounce(query, 300);
 
   // Build Trie from index-derived suggestions (real course titles / words)
   // falling back to static keywords until the index is ready.
   const suggestionTrie = useMemo(() => {
-    const words = indexReady && indexSuggestions.length > 0
-      ? indexSuggestions
-      : FALLBACK_KEYWORDS;
+    const words = indexReady && indexSuggestions.length > 0 ? indexSuggestions : FALLBACK_KEYWORDS;
     return buildTrie(words);
   }, [indexReady, indexSuggestions]);
 
@@ -125,47 +136,50 @@ export const MobileSearch = ({
       setQueryError(null);
       const trimmed = searchQuery.trim();
       addToSearchHistory(trimmed);
-      trackEvent(AnalyticsEvent.SEARCH_QUERY, { query: trimmed, filters: filterValues });
+      trackEvent(AnalyticsEvent.SEARCH_QUERY, {
+        query: trimmed,
+        filters: JSON.stringify(filterValues),
+      });
 
       const found = indexSearch(trimmed, filterValues);
       setResults(found);
       setHasSearched(true);
       setSuggestionsVisible(false);
     },
-    [filterValues, trackEvent, indexSearch],
+    [filterValues, trackEvent, indexSearch]
   );
 
   const handleResultPress = useCallback(
     (item: SearchResultItem) => onResultPress?.(item),
-    [onResultPress],
+    [onResultPress]
   );
 
   React.useEffect(() => {
     const trimmed = debouncedQuery.trim();
 
-    searchAbortRef.current?.abort();
-    searchAbortRef.current = null;
-
     if (trimmed) {
-      const controller = new AbortController();
-      searchAbortRef.current = controller;
-      setIsSearching(true);
-
-      try {
-        if (!controller.signal.aborted) {
-          performSearch(trimmed);
-        }
-      } finally {
-        if (!controller.signal.aborted) {
-          setIsSearching(false);
-        }
+      const validation = validateSearchQuery(trimmed);
+      if (!validation.valid) {
+        setQueryError(validation.message ?? 'Invalid search query.');
+        setResults([]);
+        setHasSearched(false);
+        return;
       }
+
+      setQueryError(null);
+      addToSearchHistory(trimmed);
+      trackEvent(AnalyticsEvent.SEARCH_QUERY, {
+        query: trimmed,
+        filters: JSON.stringify(filterValues),
+      });
+      setResults(indexedResults);
+      setHasSearched(true);
+      setSuggestionsVisible(false);
     } else {
-      setIsSearching(false);
       setResults((prev: SearchResultItem[]) => (prev.length === 0 ? prev : []));
       setHasSearched((prev: boolean) => (prev ? false : prev));
     }
-  }, [debouncedQuery, performSearch]);
+  }, [debouncedQuery, filterValues, indexedResults, trackEvent]);
 
   const handleSubmit = useCallback(() => performSearch(query), [query, performSearch]);
 
@@ -174,7 +188,7 @@ export const MobileSearch = ({
       setQuery(text);
       performSearch(text);
     },
-    [performSearch],
+    [performSearch]
   );
 
   const handleHistorySelect = useCallback(
@@ -182,7 +196,7 @@ export const MobileSearch = ({
       setQuery(text);
       performSearch(text);
     },
-    [performSearch],
+    [performSearch]
   );
 
   const handleVoiceResult = useCallback(
@@ -190,7 +204,7 @@ export const MobileSearch = ({
       setQuery(text);
       performSearch(text);
     },
-    [performSearch],
+    [performSearch]
   );
 
   const handleApplyFilters = useCallback((values: FilterValues) => {

--- a/src/hooks/useSearchIndex.ts
+++ b/src/hooks/useSearchIndex.ts
@@ -1,14 +1,30 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 
+import { useDebounce } from './useDebounce';
 import { FilterValues } from '../components/mobile/FilterSheet';
 import { SearchResultItem } from '../components/mobile/SearchResultCard';
 import { courseApi } from '../services/api/courseApi';
 import { searchIndexService } from '../services/searchIndex';
 import { appLogger } from '../utils/logger';
 
+export interface UseSearchIndexOptions {
+  /** Query to debounce and search against the already-mounted index. */
+  query?: string;
+  /** Search filters applied to the debounced query. */
+  filters?: FilterValues;
+  /** Debounce delay for query-driven searches. */
+  debounceMs?: number;
+}
+
 export interface UseSearchIndexResult {
   /** Run a search and return ranked results. Instant (<100 ms) once ready. */
   search: (query: string, filters?: FilterValues) => SearchResultItem[];
+  /** Results for the optional debounced query passed into the hook. */
+  results: SearchResultItem[];
+  /** Debounced query value used to compute `results`. */
+  debouncedQuery: string;
+  /** True while the raw query is waiting for the debounce window. */
+  isSearching: boolean;
   /** Title words / phrases suitable for autocomplete Trie seeding. */
   suggestions: string[];
   /** True when the index is loaded and ready to query. */
@@ -26,13 +42,15 @@ export interface UseSearchIndexResult {
  * If nothing is persisted it fetches courses from the API and builds the index.
  * Subsequent mounts reuse the in-memory singleton — no rebuild needed.
  */
-export function useSearchIndex(): UseSearchIndexResult {
+export function useSearchIndex(options: UseSearchIndexOptions = {}): UseSearchIndexResult {
+  const { query = '', filters = {}, debounceMs = 300 } = options;
   const [isReady, setIsReady] = useState(searchIndexService.ready);
-  const [suggestions, setSuggestions] = useState<string[]>(
-    searchIndexService.getSuggestions(),
-  );
+  const [suggestions, setSuggestions] = useState<string[]>(searchIndexService.getSuggestions());
   const [indexedCount, setIndexedCount] = useState(searchIndexService.indexedCount);
   const mounted = useRef(true);
+  const debouncedQuery = useDebounce(query, debounceMs);
+  const deferredQuery = useDeferredValue(debouncedQuery);
+  const filtersKey = useMemo(() => JSON.stringify(filters), [filters]);
 
   const sync = useCallback(() => {
     if (!mounted.current) return;
@@ -75,10 +93,27 @@ export function useSearchIndex(): UseSearchIndexResult {
   }, [rebuild, sync]);
 
   const search = useCallback(
-    (query: string, filters?: FilterValues) =>
-      searchIndexService.search(query, filters),
-    [],
+    (query: string, filters?: FilterValues) => searchIndexService.search(query, filters),
+    []
   );
 
-  return { search, suggestions, isReady, indexedCount, rebuild };
+  const results = useMemo(() => {
+    const trimmed = deferredQuery.trim();
+    if (!trimmed || !isReady) return [];
+    return searchIndexService.search(trimmed, filters);
+    // filtersKey intentionally re-runs the memo when callers provide a new
+    // object with equivalent values but a different reference.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deferredQuery, filtersKey, isReady]);
+
+  return {
+    search,
+    results,
+    debouncedQuery,
+    isSearching: query !== debouncedQuery,
+    suggestions,
+    isReady,
+    indexedCount,
+    rebuild,
+  };
 }

--- a/src/services/searchIndex.ts
+++ b/src/services/searchIndex.ts
@@ -20,12 +20,64 @@ const FIELD_WEIGHTS = {
 } as const;
 
 const STOP_WORDS = new Set([
-  'a', 'an', 'the', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
-  'of', 'with', 'by', 'from', 'is', 'are', 'was', 'be', 'been', 'being',
-  'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could',
-  'should', 'may', 'might', 'can', 'this', 'that', 'these', 'those',
-  'it', 'its', 'you', 'your', 'we', 'our', 'they', 'their', 'he', 'she',
-  'as', 'if', 'not', 'no', 'so', 'up', 'out', 'about', 'more', 'also',
+  'a',
+  'an',
+  'the',
+  'and',
+  'or',
+  'but',
+  'in',
+  'on',
+  'at',
+  'to',
+  'for',
+  'of',
+  'with',
+  'by',
+  'from',
+  'is',
+  'are',
+  'was',
+  'be',
+  'been',
+  'being',
+  'have',
+  'has',
+  'had',
+  'do',
+  'does',
+  'did',
+  'will',
+  'would',
+  'could',
+  'should',
+  'may',
+  'might',
+  'can',
+  'this',
+  'that',
+  'these',
+  'those',
+  'it',
+  'its',
+  'you',
+  'your',
+  'we',
+  'our',
+  'they',
+  'their',
+  'he',
+  'she',
+  'as',
+  'if',
+  'not',
+  'no',
+  'so',
+  'up',
+  'out',
+  'about',
+  'more',
+  'also',
 ]);
 
 interface IndexEntry {
@@ -62,7 +114,7 @@ function addEntry(
   entries: Record<string, IndexEntry[]>,
   token: string,
   docId: string,
-  score: number,
+  score: number
 ): void {
   const list = (entries[token] ??= []);
   const existing = list.find(e => e.docId === docId);
@@ -70,6 +122,24 @@ function addEntry(
     existing.score += score;
   } else {
     list.push({ docId, score });
+  }
+}
+
+function addWeightedTokens(
+  entries: Record<string, IndexEntry[]>,
+  tokens: string[],
+  docId: string,
+  weight: number
+): void {
+  if (tokens.length === 0) return;
+
+  const counts = new Map<string, number>();
+  for (const token of tokens) {
+    counts.set(token, (counts.get(token) ?? 0) + 1);
+  }
+
+  for (const [token, count] of counts) {
+    addEntry(entries, token, docId, weight * (count / tokens.length));
   }
 }
 
@@ -85,7 +155,7 @@ function courseToDoc(course: Course): SearchResultItem {
   };
 }
 
-function buildIndex(courses: Course[]): PersistedSearchIndex {
+export function buildSearchIndex(courses: Course[]): PersistedSearchIndex {
   const entries: Record<string, IndexEntry[]> = {};
   const docs: Record<string, SearchResultItem> = {};
   const suggestionSet = new Set<string>();
@@ -102,10 +172,7 @@ function buildIndex(courses: Course[]): PersistedSearchIndex {
 
     // Title
     const titleTokens = tokenize(course.title);
-    for (const token of titleTokens) {
-      const tf = titleTokens.filter(t => t === token).length / titleTokens.length;
-      addEntry(entries, token, course.id, FIELD_WEIGHTS.title * tf);
-    }
+    addWeightedTokens(entries, titleTokens, course.id, FIELD_WEIGHTS.title);
 
     // Category
     for (const token of tokenize(course.category)) {
@@ -119,10 +186,7 @@ function buildIndex(courses: Course[]): PersistedSearchIndex {
 
     // Description (length-capped)
     const descTokens = tokenize(course.description, MAX_DESC_TOKENS);
-    for (const token of descTokens) {
-      const tf = descTokens.filter(t => t === token).length / descTokens.length;
-      addEntry(entries, token, course.id, FIELD_WEIGHTS.description * tf);
-    }
+    addWeightedTokens(entries, descTokens, course.id, FIELD_WEIGHTS.description);
   }
 
   // Pre-sort each posting list by score descending so top hits come first.
@@ -142,7 +206,7 @@ function buildIndex(courses: Course[]): PersistedSearchIndex {
 
 // ─── Service ──────────────────────────────────────────────────────────────────
 
-class SearchIndexService {
+export class SearchIndexService {
   private index: PersistedSearchIndex | null = null;
   // Trie over the index vocabulary (token strings) for fast prefix lookup.
   private tokenTrie: Trie | null = null;
@@ -187,10 +251,10 @@ class SearchIndexService {
    */
   async buildFromCourses(courses: Course[]): Promise<void> {
     const start = Date.now();
-    const idx = buildIndex(courses);
+    const idx = buildSearchIndex(courses);
     this._mount(idx);
     appLogger.infoSync(
-      `[SearchIndex] built ${idx.courseIds.length} docs in ${Date.now() - start}ms`,
+      `[SearchIndex] built ${idx.courseIds.length} docs in ${Date.now() - start}ms`
     );
     await this._persist(idx);
   }

--- a/tests/services/searchIndex.perf.test.ts
+++ b/tests/services/searchIndex.perf.test.ts
@@ -1,0 +1,44 @@
+import { SearchIndexService } from '../../src/services/searchIndex';
+import { Course } from '../../src/types/course';
+
+function makeCourse(index: number): Course {
+  const category = index % 2 === 0 ? 'Mobile Development' : 'Web Development';
+  const level = index % 3 === 0 ? 'advanced' : index % 3 === 1 ? 'intermediate' : 'beginner';
+
+  return {
+    id: `course-${index}`,
+    title: `React Native Performance Patterns ${index}`,
+    description:
+      'React Native search indexing, course discovery, offline mobile learning, and performance optimization techniques.',
+    instructor: {
+      id: `instructor-${index}`,
+      name: `Instructor ${index}`,
+    },
+    sections: [],
+    totalLessons: 10,
+    totalDuration: 90,
+    level,
+    category,
+  };
+}
+
+function now(): number {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now();
+}
+
+describe('SearchIndexService performance', () => {
+  it('searches a 500-course pre-built index within the 50ms budget', async () => {
+    const service = new SearchIndexService();
+    const courses = Array.from({ length: 500 }, (_, index) => makeCourse(index));
+
+    await service.buildFromCourses(courses);
+
+    const start = now();
+    const results = service.search('react native', {}, 50);
+    const duration = now() - start;
+
+    expect(service.indexedCount).toBe(500);
+    expect(results.length).toBeGreaterThan(0);
+    expect(duration).toBeLessThan(50);
+  });
+});


### PR DESCRIPTION
## Summary
- move typed MobileSearch queries through `useSearchIndex` so searches run after the 300ms debounce window
- memoize debounced hook results and keep immediate searches for submit, history, suggestion, and voice selection paths
- optimize index weighting by counting token frequencies once per field instead of repeatedly filtering token arrays
- add a 500-course performance test proving pre-built index searches stay under the 50ms budget

Fixes #595

## Validation
- `npm test -- --runInBand tests/services/searchIndex.perf.test.ts`
- `npx eslint src\hooks\useSearchIndex.ts src\components\mobile\MobileSearch.tsx src\services\searchIndex.ts tests\services\searchIndex.perf.test.ts`

## Notes
- Full `tsc` is currently blocked by existing repo-wide type errors unrelated to this change.
- `tests/components/MobileSearch.perf.test.tsx` is blocked by a missing NetInfo native mock before it reaches this code path.
