### PR TITLE
fix(perf): debounce useFormCache AsyncStorage writes at 800ms

### DIFF
--- a/src/hooks/useFormCache.ts
+++ b/src/hooks/useFormCache.ts
@@ -10,6 +10,8 @@ import {
   loadFormCache,
 } from '../services/formCache';
 
+const DEBOUNCE_MS = 800;
+
 export function useFormCache(fieldKeys: FormCacheFieldKey[]) {
   const [prefillValues, setPrefillValues] = useState<Partial<Record<FormCacheFieldKey, string>>>(
     {}
@@ -18,6 +20,9 @@ export function useFormCache(fieldKeys: FormCacheFieldKey[]) {
   const [isLoading, setIsLoading] = useState(true);
 
   const stableFieldKeysRef = useRef(fieldKeys);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingValuesRef = useRef<Partial<Record<FormCacheFieldKey, string>> | null>(null);
+  const writeCountRef = useRef(0);
 
   useEffect(() => {
     stableFieldKeysRef.current = fieldKeys;
@@ -38,13 +43,53 @@ export function useFormCache(fieldKeys: FormCacheFieldKey[]) {
     void refresh();
   }, [refresh]);
 
-  const persistFields = useCallback(
+  // Cancel pending debounced write on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, []);
+
+  const _commitWrite = useCallback(
     async (values: Partial<Record<FormCacheFieldKey, string>>) => {
       await cacheFormValues(values);
+      writeCountRef.current += 1;
       await refresh();
     },
     [refresh]
   );
+
+  const persistFields = useCallback(
+    (values: Partial<Record<FormCacheFieldKey, string>>) => {
+      pendingValuesRef.current = values;
+
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+
+      debounceRef.current = setTimeout(() => {
+        if (pendingValuesRef.current) {
+          void _commitWrite(pendingValuesRef.current);
+          pendingValuesRef.current = null;
+        }
+        debounceRef.current = null;
+      }, DEBOUNCE_MS);
+    },
+    [_commitWrite]
+  );
+
+  const flushCache = useCallback(async () => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    if (pendingValuesRef.current) {
+      await _commitWrite(pendingValuesRef.current);
+      pendingValuesRef.current = null;
+    }
+  }, [_commitWrite]);
 
   const applyPrefillToFields = useCallback(
     (
@@ -80,6 +125,8 @@ export function useFormCache(fieldKeys: FormCacheFieldKey[]) {
     cacheStore,
     isLoading,
     persistFields,
+    flushCache,
+    writeCount: writeCountRef.current,
     applyPrefillToFields,
     getSuggestion,
     clearCache,

--- a/tests/hooks/useFormCache.test.ts
+++ b/tests/hooks/useFormCache.test.ts
@@ -80,7 +80,7 @@ describe('useFormCache', () => {
     expect(result.current.prefillValues).toEqual({});
   });
 
-  it('shares persisted values across form sessions', async () => {
+  it('shares persisted values across form sessions via flushCache', async () => {
     let storedValue: string | null = null;
     mockGetItem.mockImplementation(async () => storedValue);
     mockSetItem.mockImplementation(async (_key, value) => {
@@ -90,16 +90,106 @@ describe('useFormCache', () => {
     const firstForm = renderHook(() => useFormCache(['fullName', 'email']));
     await waitFor(() => expect(firstForm.result.current.isLoading).toBe(false));
 
-    await act(async () => {
-      await firstForm.result.current.persistFields({
+    act(() => {
+      firstForm.result.current.persistFields({
         fullName: 'Persisted User',
         email: 'persisted@teachlink.dev',
       });
+    });
+
+    await act(async () => {
+      await firstForm.result.current.flushCache();
     });
 
     const secondForm = renderHook(() => useFormCache(['fullName']));
     await waitFor(() => expect(secondForm.result.current.isLoading).toBe(false));
 
     expect(secondForm.result.current.prefillValues.fullName).toBe('Persisted User');
+  });
+
+  describe('debounce behavior', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('does not write to AsyncStorage before 800ms', async () => {
+      const { result } = renderHook(() => useFormCache(['email']));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => {
+        result.current.persistFields({ email: 'a' });
+      });
+      act(() => {
+        result.current.persistFields({ email: 'ab' });
+      });
+      act(() => {
+        result.current.persistFields({ email: 'abc' });
+      });
+
+      expect(mockSetItem).not.toHaveBeenCalled();
+    });
+
+    it('writes exactly once after 800ms burst', async () => {
+      const { result } = renderHook(() => useFormCache(['email']));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => {
+        result.current.persistFields({ email: 'a' });
+      });
+      act(() => {
+        result.current.persistFields({ email: 'ab' });
+      });
+      act(() => {
+        result.current.persistFields({ email: 'abc' });
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(800);
+      });
+
+      expect(mockSetItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels pending write on unmount', async () => {
+      const { result, unmount } = renderHook(() => useFormCache(['email']));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => {
+        result.current.persistFields({ email: 'test' });
+      });
+      unmount();
+
+      await act(async () => {
+        jest.advanceTimersByTime(800);
+      });
+
+      expect(mockSetItem).not.toHaveBeenCalled();
+    });
+
+    it('flushCache writes immediately and prevents double write', async () => {
+      const { result } = renderHook(() => useFormCache(['email']));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => {
+        result.current.persistFields({ email: 'flush-me' });
+      });
+
+      await act(async () => {
+        await result.current.flushCache();
+      });
+
+      expect(mockSetItem).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        jest.advanceTimersByTime(800);
+      });
+
+      // Still only 1 write — debounce was cancelled
+      expect(mockSetItem).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
Closes #599

## What was wrong

`persistFields` wrote to AsyncStorage on every keystroke. No debounce. On a 6-field form that's ~6 writes/second — enough to cause frame drops since AsyncStorage ops are serialized on the native thread.

## What I changed

- Debounced the write to 800ms after the last keystroke using `useRef` + `setTimeout`
- Added `flushCache()` for immediate writes on form submit
- Cleanup cancels any pending write on unmount so nothing fires after the component is gone
- Exposed `writeCount` for monitoring

## Tests

8/8 passing — `jest tests/hooks/useFormCache.test.ts`

Covers: debounce timing, single write after burst, unmount cancellation, flush preventing double write.

## CI failures

All failing checks are pre-existing on `main` — missing `expo-updates` package, 251 files failing Prettier repo-wide, broken Python pip cache config, missing `EXPO_TOKEN` on fork PRs. None are related to this change. No new deps introduced.