### PR TITLE
requestQueue does not validate auth token validity before replaying q…

### DIFF
--- a/src/services/api/requestQueue.ts
+++ b/src/services/api/requestQueue.ts
@@ -2,9 +2,11 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { InternalAxiosRequestConfig } from 'axios';
 import * as Network from 'expo-network';
 
+import { useAppStore } from '../../store';
 import logger from '../../utils/logger';
 import { healthMetricsService } from '../healthMetrics';
 import { mobileAnalyticsService } from '../mobileAnalytics';
+import { isSessionValid, refreshAccessToken } from '../secureStorage';
 
 export type RequestPriority = 'critical' | 'high' | 'normal' | 'low';
 
@@ -158,6 +160,19 @@ class RequestQueue {
     }
   }
 
+  async clear(): Promise<void> {
+    try {
+      await AsyncStorage.setItem(QUEUE_KEY, JSON.stringify([]));
+      this.metrics.totalQueued = 0;
+      this.metrics.byPriority = { critical: 0, high: 0, normal: 0, low: 0 };
+      this.metrics.byMethod = {};
+      await this.persistMetrics();
+      this.notifyListeners(0);
+    } catch (error) {
+      logger.error('Error clearing request queue:', error);
+    }
+  }
+
   async processQueue(apiClient?: any): Promise<void> {
     if (this.isProcessing) return;
 
@@ -172,6 +187,29 @@ class RequestQueue {
     try {
       const queue = await this.getQueue();
       if (queue.length === 0) return;
+
+      const sessionValid = await isSessionValid();
+      if (!sessionValid) {
+        try {
+          const refreshedTokens = await refreshAccessToken();
+          useAppStore
+            .getState()
+            .setTokens(
+              refreshedTokens.accessToken,
+              refreshedTokens.refreshToken,
+              refreshedTokens.expiresAt,
+            );
+          logger.info('RequestQueue: session refreshed before replaying queued requests');
+        } catch (error) {
+          await this.clear();
+          useAppStore.getState().logout();
+          logger.warn(
+            'RequestQueue: queued requests cleared after session refresh failed; re-authentication required',
+            error,
+          );
+          return;
+        }
+      }
 
       const validRequests = queue.filter(
         (req) => req.retries < req.maxRetries,

--- a/src/services/secureStorage.ts
+++ b/src/services/secureStorage.ts
@@ -1,6 +1,8 @@
+import axios from 'axios';
 import * as SecureStore from 'expo-secure-store';
 import { Platform } from 'react-native';
 
+import { getEnv } from '../config';
 import defaultLogger from '../utils/logger';
 
 const logger = defaultLogger;
@@ -385,6 +387,44 @@ export async function isSessionValid(): Promise<boolean> {
 
   // Consider session expired 30s early to allow refresh
   return expiresAt > Date.now() + 30_000;
+}
+
+interface RefreshTokenResponse {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+}
+
+/**
+ * Refresh the access token using the stored refresh token.
+ */
+export async function refreshAccessToken(): Promise<RefreshTokenResponse> {
+  if (!isSecureStorageReady()) {
+    throw new Error('SecureStorage not initialized - cannot refresh tokens');
+  }
+
+  const refreshToken = await getRefreshToken();
+  if (!refreshToken) {
+    throw new Error('No refresh token available. Please log in again.');
+  }
+
+  const baseURL = getEnv('EXPO_PUBLIC_API_BASE_URL');
+  const { data } = await axios.post(`${baseURL}/auth/refresh`, {
+    refreshToken,
+  });
+
+  const tokens = data?.tokens ?? data;
+  if (!tokens?.accessToken || !tokens?.refreshToken || !tokens?.expiresAt) {
+    throw new Error('Refresh response did not include a complete token set.');
+  }
+
+  await saveTokens(tokens.accessToken, tokens.refreshToken, tokens.expiresAt);
+
+  return {
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+    expiresAt: tokens.expiresAt,
+  };
 }
 
 // ─── Export manifest (for verification in tests) ────────────────────────────────

--- a/tests/services/api/requestQueue.test.ts
+++ b/tests/services/api/requestQueue.test.ts
@@ -3,6 +3,8 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Network from 'expo-network';
 
 import { requestQueue } from '../../../src/services/api/requestQueue';
+import * as secureStorage from '../../../src/services/secureStorage';
+import { useAppStore } from '../../../src/store';
 
 jest.mock('../../../src/utils/logger', () => ({
   __esModule: true,
@@ -26,6 +28,20 @@ jest.mock('../../../src/services/mobileAnalytics', () => ({
   },
 }));
 
+jest.mock('../../../src/services/secureStorage', () => ({
+  isSessionValid: jest.fn(() => Promise.resolve(true)),
+  refreshAccessToken: jest.fn(),
+}));
+
+jest.mock('../../../src/store', () => ({
+  useAppStore: {
+    getState: jest.fn(() => ({
+      logout: jest.fn(),
+      setTokens: jest.fn(),
+    })),
+  },
+}));
+
 const mockConfig = (overrides: Partial<InternalAxiosRequestConfig> = {}): InternalAxiosRequestConfig =>
   ({
     method: 'GET',
@@ -36,8 +52,27 @@ const mockConfig = (overrides: Partial<InternalAxiosRequestConfig> = {}): Intern
   }) as InternalAxiosRequestConfig;
 
 describe('RequestQueue', () => {
+  const mockIsSessionValid = secureStorage.isSessionValid as jest.MockedFunction<
+    typeof secureStorage.isSessionValid
+  >;
+  const mockRefreshAccessToken = secureStorage.refreshAccessToken as jest.MockedFunction<
+    typeof secureStorage.refreshAccessToken
+  >;
+  const mockLogout = jest.fn();
+  const mockSetTokens = jest.fn();
+
   beforeEach(async () => {
     jest.clearAllMocks();
+    (useAppStore.getState as jest.Mock).mockReturnValue({
+      logout: mockLogout,
+      setTokens: mockSetTokens,
+    });
+    mockIsSessionValid.mockResolvedValue(true);
+    mockRefreshAccessToken.mockResolvedValue({
+      accessToken: 'fresh-access-token',
+      refreshToken: 'fresh-refresh-token',
+      expiresAt: Date.now() + 3_600_000,
+    });
 
     const queue = await requestQueue.getQueue();
     for (const req of queue) {
@@ -154,6 +189,43 @@ describe('RequestQueue', () => {
       const queue = await requestQueue.getQueue();
       expect(queue).toHaveLength(0);
       expect(client).toHaveBeenCalledTimes(1);
+      expect(mockIsSessionValid).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refresh the session before replay when the access token expired', async () => {
+      mockIsSessionValid.mockResolvedValue(false);
+      const client = jest.fn().mockResolvedValue({ data: 'ok' });
+      await requestQueue.addToQueue(mockConfig());
+
+      await requestQueue.processQueue(client);
+
+      expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+      expect(mockSetTokens).toHaveBeenCalledWith(
+        'fresh-access-token',
+        'fresh-refresh-token',
+        expect.any(Number),
+      );
+      expect(client).toHaveBeenCalledTimes(1);
+
+      const queue = await requestQueue.getQueue();
+      expect(queue).toHaveLength(0);
+    });
+
+    it('should clear the queue and log the user out when refresh fails', async () => {
+      mockIsSessionValid.mockResolvedValue(false);
+      mockRefreshAccessToken.mockRejectedValue(new Error('Refresh token expired'));
+      const client = jest.fn().mockResolvedValue({ data: 'ok' });
+      await requestQueue.addToQueue(mockConfig());
+
+      await requestQueue.processQueue(client);
+
+      expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+      expect(mockLogout).toHaveBeenCalledTimes(1);
+      expect(mockSetTokens).not.toHaveBeenCalled();
+      expect(client).not.toHaveBeenCalled();
+
+      const queue = await requestQueue.getQueue();
+      expect(queue).toHaveLength(0);
     });
 
     it('should handle network errors during processing', async () => {


### PR DESCRIPTION
Prevent queued offline requests from replaying with an expired session.
This change adds a session-validity preflight to offline queue replay. Before processing queued requests, requestQueue.processQueue() now checks isSessionValid(). If the session is no longer valid, it attempts a token refresh first. Replay only continues after a confirmed successful refresh. If refresh fails, the queue is cleared and the user is logged out to avoid repeated 401/refresh failure loops after long offline periods.
Tests were added to cover:
valid session: queue replays normally
expired access token with valid refresh token: refresh happens, then replay proceeds
expired refresh token: queue is cleared and logout is triggered
Closes #624