### PR TITLE
fix: handle AsyncStorage quota exceeded by clearing pending analytics queue

### DIFF
--- a/src/__tests__/utils/storage.test.ts
+++ b/src/__tests__/utils/storage.test.ts
@@ -1,0 +1,76 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Sentry from '@sentry/react-native';
+
+import { safeStorageWrite, __resetQuotaErrorState } from '../../utils/storage';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+describe('safeStorageWrite', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetQuotaErrorState();
+  });
+
+  it('should write successfully on first attempt', async () => {
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValueOnce(undefined);
+    const result = await safeStorageWrite('test-key', 'test-value');
+    expect(result).toBe(true);
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('test-key', 'test-value');
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('should catch quota error, clear analytics, and retry successfully', async () => {
+    const quotaError = new Error('Quota exceeded');
+    quotaError.name = 'QuotaExceededError';
+
+    (AsyncStorage.setItem as jest.Mock)
+      .mockRejectedValueOnce(quotaError) // First attempt fails
+      .mockResolvedValueOnce(undefined); // Second attempt succeeds
+
+    const result = await safeStorageWrite('test-key', 'test-value');
+    
+    expect(result).toBe(true);
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('@analytics/pending');
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(2);
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('should return false for non-quota errors and not retry', async () => {
+    const normalError = new Error('Some other error');
+    (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(normalError);
+
+    const result = await safeStorageWrite('test-key', 'test-value');
+    
+    expect(result).toBe(false);
+    expect(AsyncStorage.removeItem).not.toHaveBeenCalled();
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('should report to Sentry only once per session if retry fails', async () => {
+    const quotaError = new Error('Quota exceeded');
+    quotaError.name = 'QuotaExceededError';
+
+    (AsyncStorage.setItem as jest.Mock)
+      .mockRejectedValueOnce(quotaError) // First call fails
+      .mockRejectedValueOnce(quotaError) // Retry fails
+      .mockRejectedValueOnce(quotaError) // Next call fails
+      .mockRejectedValueOnce(quotaError); // Next retry fails
+
+    // First attempt -> retry fails -> Sentry reported
+    const result1 = await safeStorageWrite('test-key1', 'test-value1');
+    expect(result1).toBe(false);
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+
+    // Second attempt -> retry fails -> Sentry NOT reported
+    const result2 = await safeStorageWrite('test-key2', 'test-value2');
+    expect(result2).toBe(false);
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/config/logging.ts
+++ b/src/config/logging.ts
@@ -59,6 +59,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Sentry from '@sentry/react-native';
 
 import { sentryContextService } from '../services/sentryContext';
+import { safeStorageWrite } from '../utils/storage';
 
 // ─── CONFIGURATION ─────────────────────────────────────────────────────────
 
@@ -197,7 +198,7 @@ async function persistBatch(entries: StructuredLogEntry[]): Promise<void> {
     }
 
     const newLog = currentLog ? `${currentLog}\n${logData}` : logData;
-    await AsyncStorage.setItem(storageKey, newLog);
+    await safeStorageWrite(storageKey, newLog);
   } catch {
     // Silent fail for storage errors
   }
@@ -229,7 +230,7 @@ async function rotateLogFiles(): Promise<void> {
       const currentLog = await AsyncStorage.getItem(logKeys[0]);
       if (currentLog) {
         const archiveKey = `${LOG_STORAGE_PREFIX}/archive/${Date.now()}`;
-        await AsyncStorage.setItem(archiveKey, currentLog);
+        await safeStorageWrite(archiveKey, currentLog);
       }
     }
 
@@ -241,7 +242,7 @@ async function rotateLogFiles(): Promise<void> {
     }
 
     // Clear current log
-    await AsyncStorage.setItem(`${LOG_STORAGE_PREFIX}/current`, '');
+    await safeStorageWrite(`${LOG_STORAGE_PREFIX}/current`, '');
   } catch {
     // Silent fail
   }

--- a/src/services/analytics/AnalyticsBatchQueue.ts
+++ b/src/services/analytics/AnalyticsBatchQueue.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Sentry from '@sentry/react-native';
 
 import { appLogger } from '../../utils/logger';
+import { safeStorageWrite } from '../../utils/storage';
 import { AnalyticsEvent, EventProperties } from '../../utils/trackingEvents';
 import apiClient from '../api/axios.config';
 
@@ -115,7 +116,7 @@ export class AnalyticsBatchQueue {
 
   private async storeBatch(events: AnalyticsEventEntry[], retryCount: number): Promise<void> {
     try {
-      await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ events, retryCount }));
+      await safeStorageWrite(STORAGE_KEY, JSON.stringify({ events, retryCount }));
     } catch {
       /* silent */
     }

--- a/src/services/formCache.ts
+++ b/src/services/formCache.ts
@@ -1,5 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
+import { safeStorageWrite } from '../utils/storage';
+
 /** AsyncStorage key for the form value cache (versioned for future migrations). */
 export const FORM_CACHE_STORAGE_KEY = '@teachlink/form-cache/v1';
 
@@ -62,7 +64,7 @@ export async function loadFormCache(): Promise<FormCacheStore> {
 }
 
 export async function saveFormCache(store: FormCacheStore): Promise<void> {
-  await AsyncStorage.setItem(FORM_CACHE_STORAGE_KEY, JSON.stringify(store));
+  await safeStorageWrite(FORM_CACHE_STORAGE_KEY, JSON.stringify(store));
 }
 
 export async function getCachedFieldValue(key: FormCacheFieldKey): Promise<string | null> {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,53 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Sentry from '@sentry/react-native';
+
+let hasReportedQuotaError = false;
+
+/**
+ * Safely writes data to AsyncStorage, handling quota exceeded errors.
+ * If a quota error occurs, it clears the oldest analytics pending queue entries
+ * and retries the write. If the retry fails, it reports the error to Sentry
+ * (once per session) and returns false.
+ *
+ * @param key - The AsyncStorage key
+ * @param value - The value to write
+ * @returns A promise that resolves to true if successful, false otherwise.
+ */
+export async function safeStorageWrite(key: string, value: string): Promise<boolean> {
+  try {
+    await AsyncStorage.setItem(key, value);
+    return true;
+  } catch (error: any) {
+    const isQuotaError =
+      error?.message?.toLowerCase().includes('quota') ||
+      error?.name?.toLowerCase().includes('quota');
+
+    if (isQuotaError) {
+      try {
+        // Clear analytics pending queue to free space
+        await AsyncStorage.removeItem('@analytics/pending');
+
+        // Retry write
+        await AsyncStorage.setItem(key, value);
+        return true;
+      } catch (retryError) {
+        if (!hasReportedQuotaError) {
+          Sentry.captureException(retryError, {
+            tags: { issue: 'async_storage_quota_exceeded' },
+          });
+          hasReportedQuotaError = true;
+        }
+        return false;
+      }
+    }
+
+    return false;
+  }
+}
+
+/**
+ * Exposed for testing purposes to reset the session quota error state.
+ */
+export function __resetQuotaErrorState() {
+  hasReportedQuotaError = false;
+}


### PR DESCRIPTION
## Description
This PR resolves issue #675 where `AsyncStorage` quota exceeded errors on Android fail silently and corrupt the application's persisted state. 

The `useFormCache`, analytics pending queue, and log rotation previously all wrote to `AsyncStorage` without checking for available space. On devices approaching the 6MB default quota limit, this caused unhandled rejections that left stale and partial data without reporting anything. 

This PR implements a centralized helper `safeStorageWrite` that handles quota errors gracefully by intercepting the failure, flushing non-critical data (the pending analytics queue) to free up space, and retrying the write.

## Changes Made
- **Created `src/utils/storage.ts`**: Introduced the `safeStorageWrite` function which wraps standard `AsyncStorage.setItem` logic.
  - Detects if an error relates to the storage quota.
  - If a quota error happens, it clears the `@analytics/pending` store to recover space.
  - Automatically retries the write operation.
  - Limits Sentry reporting to a maximum of 1 quota error telemetry ping per session if the retry still fails, preventing massive log bursts.
- **Form Cache (`src/services/formCache.ts`)**: Updated `saveFormCache` to utilize `safeStorageWrite` instead of the raw method.
- **Log Rotation (`src/config/logging.ts`)**: Refactored `persistBatch` and rotation methods to use the new safe wrapper.
- **Analytics Queue (`src/services/analytics/AnalyticsBatchQueue.ts`)**: Updated `storeBatch` to use `safeStorageWrite`.
- **Unit Tests (`src/__tests__/utils/storage.test.ts`)**: Added comprehensive test coverage confirming the retry functionality, Sentry rate-limiting, and standard successes/failures.

## Fixes Issue
Closes #675 

## Verification
- Unit tests written to simulate `AsyncStorage` quota exceeded errors and verify that retry logic successfully fires and succeeds.
- Sentry call count asserted to ensure we only report once per session.
