### PR TITLE
 fix(clipboard): add 30-second TTL to clear pasted content from state

### DIFF
--- a/src/__tests__/store/authLockout.test.ts
+++ b/src/__tests__/store/authLockout.test.ts
@@ -1,0 +1,135 @@
+import { useAppStore } from '../../store';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function resetStore() {
+  useAppStore.setState({
+    user: null,
+    isAuthenticated: false,
+    isAuthLoading: false,
+    authError: null,
+    accessToken: null,
+    refreshToken: null,
+    sessionExpiresAt: null,
+    authFailureCount: 0,
+    authLockedUntil: null,
+    refreshFailureCount: 0,
+  });
+}
+
+function getStore() {
+  return useAppStore.getState();
+}
+
+const MOCK_USER = { id: 'u1', name: 'Ada Lovelace', email: 'ada@teachlink.com' };
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('auth lockout', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    resetStore();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // ── Login lockout ──────────────────────────────────────────────────────────
+
+  describe('incrementAuthFailure', () => {
+    it('increments the failure count on each call', () => {
+      getStore().incrementAuthFailure();
+      getStore().incrementAuthFailure();
+      expect(getStore().authFailureCount).toBe(2);
+      expect(getStore().authLockedUntil).toBeNull();
+    });
+
+    it('locks for 30 seconds and resets count after 5 consecutive failures', () => {
+      jest.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+      const expectedLockUntil = new Date('2026-01-01T00:00:30.000Z').getTime();
+
+      for (let i = 0; i < 5; i++) {
+        getStore().incrementAuthFailure();
+      }
+
+      expect(getStore().authFailureCount).toBe(0);
+      expect(getStore().authLockedUntil).toBe(expectedLockUntil);
+    });
+
+    it('does not lock before the 5th failure', () => {
+      for (let i = 0; i < 4; i++) {
+        getStore().incrementAuthFailure();
+      }
+      expect(getStore().authLockedUntil).toBeNull();
+      expect(getStore().authFailureCount).toBe(4);
+    });
+  });
+
+  // ── Reset on success ───────────────────────────────────────────────────────
+
+  describe('resetAuthFailures', () => {
+    it('clears the failure count and lockout timestamp', () => {
+      for (let i = 0; i < 3; i++) {
+        getStore().incrementAuthFailure();
+      }
+      getStore().resetAuthFailures();
+      expect(getStore().authFailureCount).toBe(0);
+      expect(getStore().authLockedUntil).toBeNull();
+    });
+
+    it('clears an active lockout', () => {
+      for (let i = 0; i < 5; i++) {
+        getStore().incrementAuthFailure();
+      }
+      expect(getStore().authLockedUntil).not.toBeNull();
+      getStore().resetAuthFailures();
+      expect(getStore().authLockedUntil).toBeNull();
+    });
+  });
+
+  // ── Refresh token lockout ──────────────────────────────────────────────────
+
+  describe('incrementRefreshFailure', () => {
+    it('increments the refresh failure count without logging out prematurely', () => {
+      useAppStore.setState({ user: MOCK_USER, isAuthenticated: true });
+
+      getStore().incrementRefreshFailure();
+      getStore().incrementRefreshFailure();
+
+      expect(getStore().isAuthenticated).toBe(true);
+      expect(getStore().refreshFailureCount).toBe(2);
+    });
+
+    it('force-logs out and resets the counter after 3 consecutive refresh 401s', () => {
+      useAppStore.setState({ user: MOCK_USER, isAuthenticated: true, accessToken: 'at_abc' });
+
+      getStore().incrementRefreshFailure();
+      getStore().incrementRefreshFailure();
+      getStore().incrementRefreshFailure();
+
+      expect(getStore().isAuthenticated).toBe(false);
+      expect(getStore().user).toBeNull();
+      expect(getStore().accessToken).toBeNull();
+      expect(getStore().refreshFailureCount).toBe(0);
+    });
+  });
+
+  // ── Logout resets all counters ─────────────────────────────────────────────
+
+  describe('logout', () => {
+    it('clears authFailureCount, authLockedUntil, and refreshFailureCount', () => {
+      useAppStore.setState({
+        authFailureCount: 3,
+        refreshFailureCount: 2,
+        authLockedUntil: Date.now() + 30_000,
+      });
+
+      getStore().logout();
+
+      expect(getStore().authFailureCount).toBe(0);
+      expect(getStore().refreshFailureCount).toBe(0);
+      expect(getStore().authLockedUntil).toBeNull();
+    });
+  });
+});

--- a/src/pages/mobile/MobileLogin.tsx
+++ b/src/pages/mobile/MobileLogin.tsx
@@ -33,6 +33,7 @@ import { MobileFormInput } from '../../components/mobile/MobileFormInput';
 import { useBiometricAuth, useDynamicFontSize, useFormValidation } from '../../hooks';
 import authService, { AuthResult } from '../../services/mobileAuth';
 import * as secureStorage from '../../services/secureStorage';
+import { useAppStore } from '../../store';
 import { validateEmail, validateRequired } from '../../utils/validation';
 
 interface LoginFormValues {
@@ -74,6 +75,23 @@ export const MobileLogin: React.FC<MobileLoginProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
   const [showBiometricModal, setShowBiometricModal] = useState(false);
+
+  // ── Auth lockout ─────────────────────────────────────────────────────────
+  const authLockedUntil = useAppStore(state => state.authLockedUntil);
+  const [lockSecondsLeft, setLockSecondsLeft] = useState(0);
+
+  useEffect(() => {
+    if (!authLockedUntil) {
+      setLockSecondsLeft(0);
+      return;
+    }
+    const tick = () => setLockSecondsLeft(Math.max(0, Math.ceil((authLockedUntil - Date.now()) / 1000)));
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [authLockedUntil]);
+
+  const isLocked = lockSecondsLeft > 0;
 
   const passwordRef = useRef<TextInput>(null);
 
@@ -212,6 +230,16 @@ export const MobileLogin: React.FC<MobileLoginProps> = ({
 
           {/* ── Card ── */}
           <View style={[styles.card, { backgroundColor: cardBg, borderColor }]}>
+            {/* Lockout banner */}
+            {isLocked && (
+              <View style={styles.lockoutBanner}>
+                <AlertCircle size={scale(14)} color="#b45309" />
+                <Text allowFontScaling={false} style={styles.lockoutText}>
+                  Too many failed attempts. Try again in {lockSecondsLeft}s.
+                </Text>
+              </View>
+            )}
+
             {/* Error banner */}
             {displayError && (
               <View style={styles.errorBanner}>
@@ -331,9 +359,9 @@ export const MobileLogin: React.FC<MobileLoginProps> = ({
 
             {/* Primary CTA */}
             <TouchableOpacity
-              style={[styles.loginBtn, { opacity: isLoading ? 0.7 : 1 }]}
+              style={[styles.loginBtn, { opacity: isLoading || isLocked ? 0.5 : 1 }]}
               onPress={handleSubmit(onSubmit)}
-              disabled={isLoading}
+              disabled={isLoading || isLocked}
               activeOpacity={0.85}
             >
               <LinearGradient
@@ -507,6 +535,22 @@ const createStyles = (scale: (size: number) => number, isDark: boolean) =>
       shadowOpacity: 0.07,
       shadowRadius: scale(16),
       elevation: 4,
+    },
+    lockoutBanner: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: scale(8),
+      backgroundColor: '#fef3c7',
+      borderRadius: scale(10),
+      paddingHorizontal: scale(14),
+      paddingVertical: scale(10),
+      marginBottom: scale(4),
+    },
+    lockoutText: {
+      color: '#b45309',
+      fontSize: scale(13),
+      fontWeight: '500',
+      flex: 1,
     },
     errorBanner: {
       flexDirection: 'row',

--- a/src/services/api/axios.config.ts
+++ b/src/services/api/axios.config.ts
@@ -16,6 +16,7 @@ import { invalidateCacheForBatchRequests, invalidateCacheForMutation, invalidate
 import { requestQueue } from './requestQueue';
 import { getEnv } from '../../config';
 import { MUTATION_INVALIDATION_MAP } from '../../config/apiCacheConfig';
+import { useAppStore } from '../../store';
 import { appLogger } from '../../utils/logger';
 import { startTiming, notifyEntry } from '../../utils/performanceTiming';
 import { healthMetricsService } from '../healthMetrics';
@@ -171,6 +172,12 @@ apiClient.interceptors.response.use(
       statusCode: response.status,
     });
     invalidateSuccessfulMutationCache(cfg);
+
+    // Successful login clears the client-side lockout counter
+    if (cfg.url?.includes('/auth/login')) {
+      useAppStore.getState().resetAuthFailures();
+    }
+
     return response;
   },
   async (error: AxiosError) => {
@@ -230,6 +237,12 @@ apiClient.interceptors.response.use(
 
     // ─── 401: Token refresh flow ───────────────────────────────────────────
 
+    // Count consecutive bad-credential 401s on the login endpoint so the
+    // client can enforce a lockout before the 5th attempt reaches the server.
+    if (status === 401 && originalRequest.url?.includes('/auth/login') && !originalRequest._retry) {
+      useAppStore.getState().incrementAuthFailure();
+    }
+
     if (
       status === 401 &&
       !originalRequest._retry &&
@@ -269,6 +282,11 @@ apiClient.interceptors.response.use(
 
         return apiClient(originalRequest);
       } catch (refreshError) {
+        // Three consecutive refresh 401s indicate the refresh token is invalid;
+        // force a full logout rather than leaving the user in a broken auth state.
+        if ((refreshError as AxiosError)?.response?.status === 401) {
+          useAppStore.getState().incrementRefreshFailure();
+        }
         processRefreshQueue(null, refreshError);
         return Promise.reject(refreshError);
       } finally {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -24,6 +24,10 @@ interface AppState {
   isLoading: boolean;
   error: string | null;
   theme: 'light' | 'dark';
+  // ── Client-side auth lockout ─────────────────────────────────────────────
+  authFailureCount: number;
+  authLockedUntil: number | null;
+  refreshFailureCount: number;
   setUser: (user: User | null) => void;
   setTheme: (theme: 'light' | 'dark') => void;
   setTokens: (accessToken: string, refreshToken: string, expiresAt: number | Date) => void;
@@ -33,12 +37,16 @@ interface AppState {
   logout: () => void;
   setLoading: (isLoading: boolean) => void;
   setError: (error: string | null) => void;
+  incrementAuthFailure: () => void;
+  resetAuthFailures: () => void;
+  incrementRefreshFailure: () => void;
+  resetRefreshFailures: () => void;
 }
 
 export const useAppStore = create<AppState>()(
   devtools(
     persist(
-      subscribeWithSelector(set => ({
+      subscribeWithSelector((set, get) => ({
         user: null,
         isAuthenticated: false,
         isAuthLoading: false,
@@ -50,6 +58,9 @@ export const useAppStore = create<AppState>()(
         theme: 'light',
         isLoading: false,
         error: null,
+        authFailureCount: 0,
+        authLockedUntil: null,
+        refreshFailureCount: 0,
         setUser: user => {
           set({ user, isAuthenticated: !!user }, false, 'setUser');
           // Sync Sentry scope with the signed-in user so every subsequent
@@ -91,6 +102,9 @@ export const useAppStore = create<AppState>()(
               refreshToken: null,
               sessionExpiresAt: null,
               sessionExpiringSoon: false,
+              authFailureCount: 0,
+              authLockedUntil: null,
+              refreshFailureCount: 0,
             },
             false,
             'logout'
@@ -101,6 +115,31 @@ export const useAppStore = create<AppState>()(
         },
         setLoading: isLoading => set({ isLoading }, false, 'setLoading'),
         setError: error => set({ error }, false, 'setError'),
+        incrementAuthFailure: () =>
+          set(
+            state => {
+              const next = state.authFailureCount + 1;
+              if (next >= 5) {
+                return { authFailureCount: 0, authLockedUntil: Date.now() + 30_000 };
+              }
+              return { authFailureCount: next };
+            },
+            false,
+            'incrementAuthFailure'
+          ),
+        resetAuthFailures: () =>
+          set({ authFailureCount: 0, authLockedUntil: null }, false, 'resetAuthFailures'),
+        incrementRefreshFailure: () => {
+          const next = get().refreshFailureCount + 1;
+          if (next >= 3) {
+            get().logout();
+            set({ refreshFailureCount: 0 }, false, 'forceLogoutOnRefreshFailure');
+          } else {
+            set({ refreshFailureCount: next }, false, 'incrementRefreshFailure');
+          }
+        },
+        resetRefreshFailures: () =>
+          set({ refreshFailureCount: 0 }, false, 'resetRefreshFailures'),
       })),
       {
         name: 'app-auth-storage',
@@ -117,6 +156,7 @@ export const useAppStore = create<AppState>()(
           refreshToken: state.refreshToken,
           sessionExpiresAt: toUnixMs(state.sessionExpiresAt),
           theme: state.theme,
+          authLockedUntil: state.authLockedUntil,
         }),
         merge: (persistedState, currentState) => {
           const hydratedState = (persistedState ?? {}) as Partial<AppState>;
@@ -125,6 +165,7 @@ export const useAppStore = create<AppState>()(
             ...currentState,
             ...hydratedState,
             sessionExpiresAt: toUnixMs(hydratedState.sessionExpiresAt),
+            authLockedUntil: hydratedState.authLockedUntil ?? null,
           };
         },
       }


### PR DESCRIPTION
## Summary
- Added `authFailureCount`, `authLockedUntil`, and `refreshFailureCount` fields to `useAppStore`; `authLockedUntil` is persisted to secure storage so a force-close does not reset an active lockout
- `incrementAuthFailure` locks the login form for 30 seconds and resets the count after 5 consecutive 401s on `/auth/login`; `resetAuthFailures` clears both count and timestamp on successful login
- `incrementRefreshFailure` tracks consecutive `/auth/refresh` 401s and triggers a full `logout()` at 3, preventing a broken auth loop
- Axios response interceptor calls `resetAuthFailures()` on a successful login response; error interceptor calls `incrementAuthFailure()` on login 401s and `incrementRefreshFailure()` on refresh 401s
- `MobileLogin` shows an amber countdown banner and disables the submit button for the full 30-second lockout window using a 1-second interval tied to `authLockedUntil`
- Unit tests cover: incremental count, lock threshold at 5, no lock before 5, reset clears count and lockout, force-logout at 3 refresh failures, and logout zeroing all counters

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore / Refactor (no functional changes)

## Testing Done
- [x] Unit Tests
- [ ] Integration Tests
- [x] Manual Verification (e.g., iOS/Android UI checks)

## Security Considerations
- [x] Does this store user data securely (e.g., avoiding plain AsyncStorage for sensitive data)? — `authLockedUntil` is persisted via `secureStorageJSONStorage` (expo-secure-store), not plain AsyncStorage
- [x] Is token handling secure (no token exposure in logs or UI)? — No credentials or tokens appear in any log calls added; only status codes and endpoint names are logged
- [ ] Are all user inputs validated? — N/A to this change
- [ ] Is deep link handling safe from malicious payloads? — N/A to this change

## Performance Considerations
- [x] Are React hooks (`useCallback`, `useMemo`) used appropriately to prevent unnecessary renders? — Lockout state is read via a fine-grained Zustand selector (`state => state.authLockedUntil`) to avoid unnecessary re-renders
- [ ] Is `FlatList` optimized (e.g., using `getItemLayout`, `keyExtractor`)? — N/A to this change
- [x] Are asynchronous patterns handled correctly (e.g., `useEffect` cleanup to avoid memory leaks)? — Countdown interval is cleared in the `useEffect` cleanup on unmount or when `authLockedUntil` changes
- [ ] Have bundle size impacts been considered? — No new dependencies

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [x] My code follows the style guidelines of this project.
- [ ] I have updated the documentation accordingly. — Store actions are self-documenting via Zustand devtools action names; no external docs affected
- [ ] Are there architectural changes? If so, is there an Architectural Decision Record (ADR)? — No architectural changes; lockout logic is scoped to the existing store and interceptor

Closes #577