### PR TITLE
feat(security): encrypt AsyncStorage form cache entries with AES-256-GCM (#587)

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "expo-battery": "^55.0.13",
     "expo-build-properties": "~1.0.10",
     "expo-constants": "~18.0.13",
+    "expo-crypto": "~14.0.1",
     "expo-device": "~8.0.10",
     "expo-document-picker": "~14.0.8",
     "expo-file-system": "~19.0.23",

--- a/src/__tests__/services/formCache.test.ts
+++ b/src/__tests__/services/formCache.test.ts
@@ -1,8 +1,6 @@
 /**
  * Tests for #616: useFormCache cache key is user-scoped.
  */
-import AsyncStorage from '@react-native-async-storage/async-storage';
-
 import {
   cacheFormValues,
   clearFormCache,
@@ -10,17 +8,20 @@ import {
   getFormCacheStorageKey,
   loadFormCache,
 } from '../../services/formCache';
+import { encryptedGetItem, encryptedRemoveItem, encryptedSetItem } from '../../utils/encryptedStorage';
 
-jest.mock('@react-native-async-storage/async-storage');
+jest.mock('../../utils/encryptedStorage');
 
-const mockStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+const mockGetItem = jest.mocked(encryptedGetItem);
+const mockSetItem = jest.mocked(encryptedSetItem);
+const mockRemoveItem = jest.mocked(encryptedRemoveItem);
 
 describe('formCache – user-scoped storage key (#616)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockStorage.getItem.mockResolvedValue(null);
-    mockStorage.setItem.mockResolvedValue(undefined);
-    mockStorage.removeItem.mockResolvedValue(undefined);
+    mockGetItem.mockResolvedValue(null);
+    mockSetItem.mockResolvedValue(undefined);
+    mockRemoveItem.mockResolvedValue(undefined);
   });
 
   it('generates distinct keys for different users', () => {
@@ -34,13 +35,13 @@ describe('formCache – user-scoped storage key (#616)', () => {
   it('uses user-scoped key when reading cache', async () => {
     const key = getFormCacheStorageKey('user-1');
     await loadFormCache(key);
-    expect(mockStorage.getItem).toHaveBeenCalledWith(key);
+    expect(mockGetItem).toHaveBeenCalledWith(key);
   });
 
   it('uses user-scoped key when writing cache', async () => {
     const key = getFormCacheStorageKey('user-1');
     await cacheFormValues(key, { fullName: 'Alice' });
-    expect(mockStorage.setItem).toHaveBeenCalledWith(key, expect.any(String));
+    expect(mockSetItem).toHaveBeenCalledWith(key, expect.any(String));
   });
 
   it('does not read or write to another user key', async () => {
@@ -49,7 +50,7 @@ describe('formCache – user-scoped storage key (#616)', () => {
 
     await cacheFormValues(keyA, { fullName: 'Alice' });
 
-    const allSetCalls = mockStorage.setItem.mock.calls.map(([k]) => k);
+    const allSetCalls = mockSetItem.mock.calls.map(([k]) => k);
     expect(allSetCalls).not.toContain(keyB);
   });
 
@@ -57,9 +58,8 @@ describe('formCache – user-scoped storage key (#616)', () => {
     const keyA = getFormCacheStorageKey('user-A');
     const keyB = getFormCacheStorageKey('user-B');
 
-    // Seed user-A cache with data
     const now = Date.now();
-    mockStorage.getItem.mockImplementation(k => {
+    mockGetItem.mockImplementation(k => {
       if (k === keyA)
         return Promise.resolve(JSON.stringify({ fullName: { value: 'Alice', updatedAt: now } }));
       return Promise.resolve(null);
@@ -75,7 +75,7 @@ describe('formCache – user-scoped storage key (#616)', () => {
   it('clears only the correct user key', async () => {
     const keyA = getFormCacheStorageKey('user-A');
     await clearFormCache(keyA);
-    expect(mockStorage.removeItem).toHaveBeenCalledWith(keyA);
-    expect(mockStorage.removeItem).toHaveBeenCalledTimes(1);
+    expect(mockRemoveItem).toHaveBeenCalledWith(keyA);
+    expect(mockRemoveItem).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/utils/encryptedStorage.test.ts
+++ b/src/__tests__/utils/encryptedStorage.test.ts
@@ -1,0 +1,113 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
+
+import { encryptedGetItem, encryptedRemoveItem, encryptedSetItem } from '../../utils/encryptedStorage';
+
+jest.mock('@react-native-async-storage/async-storage');
+jest.mock('expo-secure-store');
+jest.mock('expo-crypto', () => ({
+  getRandomBytes: jest.fn(() => new Uint8Array(12).fill(0x42)),
+  subtle: {
+    generateKey: jest.fn().mockResolvedValue({ type: 'secret' }),
+    exportKey: jest.fn().mockResolvedValue(new Uint8Array(32).fill(0x01).buffer),
+    importKey: jest.fn().mockResolvedValue({ type: 'secret' }),
+    encrypt: jest.fn().mockImplementation((_: unknown, __: unknown, data: Uint8Array) => {
+      const output = new Uint8Array(data.length);
+      for (let i = 0; i < data.length; i++) output[i] = data[i] ^ 0xab;
+      return Promise.resolve(output.buffer);
+    }),
+    decrypt: jest.fn().mockImplementation((_: unknown, __: unknown, data: Uint8Array) => {
+      const output = new Uint8Array(data.length);
+      for (let i = 0; i < data.length; i++) output[i] = data[i] ^ 0xab;
+      return Promise.resolve(output.buffer);
+    }),
+  },
+}));
+
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+const mockSecureStore = SecureStore as jest.Mocked<typeof SecureStore>;
+
+const STORAGE_KEY = '@teachlink/form-cache/user-1/v1';
+const PLAINTEXT = JSON.stringify({ fullName: { value: 'Alice', updatedAt: 1_000_000 } });
+
+describe('encryptedStorage – AES-256-GCM', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAsyncStorage.getItem.mockResolvedValue(null);
+    mockAsyncStorage.setItem.mockResolvedValue(undefined);
+    mockAsyncStorage.removeItem.mockResolvedValue(undefined);
+    mockSecureStore.getItemAsync.mockResolvedValue(null);
+    mockSecureStore.setItemAsync.mockResolvedValue(undefined);
+    mockSecureStore.deleteItemAsync.mockResolvedValue(undefined);
+  });
+
+  it('does not store plaintext in AsyncStorage', async () => {
+    await encryptedSetItem(STORAGE_KEY, PLAINTEXT);
+
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledTimes(1);
+    const [, storedValue] = mockAsyncStorage.setItem.mock.calls[0];
+    expect(storedValue).not.toBe(PLAINTEXT);
+    expect(storedValue).not.toContain('Alice');
+  });
+
+  it('stored payload has iv.ciphertext dot-separated format', async () => {
+    await encryptedSetItem(STORAGE_KEY, PLAINTEXT);
+
+    const [, storedValue] = mockAsyncStorage.setItem.mock.calls[0];
+    expect(storedValue.indexOf('.')).toBeGreaterThan(0);
+  });
+
+  it('creates an encryption key and persists it to SecureStore under fce. prefix', async () => {
+    await encryptedSetItem(STORAGE_KEY, PLAINTEXT);
+
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+      expect.stringMatching(/^fce\./),
+      expect.any(String)
+    );
+  });
+
+  it('returns null for a missing key', async () => {
+    const result = await encryptedGetItem(STORAGE_KEY);
+    expect(result).toBeNull();
+  });
+
+  it('returns null gracefully when stored payload has no dot separator', async () => {
+    mockAsyncStorage.getItem.mockResolvedValue('invaliddatanodot');
+    const result = await encryptedGetItem(STORAGE_KEY);
+    expect(result).toBeNull();
+  });
+
+  it('round-trips: decrypted value equals original plaintext', async () => {
+    const secureStoreData: Record<string, string> = {};
+    const asyncStorageData: Record<string, string> = {};
+
+    mockSecureStore.getItemAsync.mockImplementation(k =>
+      Promise.resolve(secureStoreData[k] ?? null)
+    );
+    mockSecureStore.setItemAsync.mockImplementation((k, v) => {
+      secureStoreData[k] = v;
+      return Promise.resolve();
+    });
+    mockAsyncStorage.setItem.mockImplementation((k, v) => {
+      asyncStorageData[k] = v;
+      return Promise.resolve();
+    });
+    mockAsyncStorage.getItem.mockImplementation(k =>
+      Promise.resolve(asyncStorageData[k] ?? null)
+    );
+
+    await encryptedSetItem(STORAGE_KEY, PLAINTEXT);
+    const result = await encryptedGetItem(STORAGE_KEY);
+
+    expect(result).toBe(PLAINTEXT);
+  });
+
+  it('removes item from AsyncStorage and deletes SecureStore key on encryptedRemoveItem', async () => {
+    await encryptedRemoveItem(STORAGE_KEY);
+
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEY);
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+      expect.stringMatching(/^fce\./)
+    );
+  });
+});

--- a/src/services/formCache.ts
+++ b/src/services/formCache.ts
@@ -1,15 +1,9 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { encryptedGetItem, encryptedRemoveItem, encryptedSetItem } from '../utils/encryptedStorage';
 
 /** Returns an AsyncStorage key scoped to the given user (versioned for future migrations). */
 export function getFormCacheStorageKey(userId: string): string {
   return `@teachlink/form-cache/${userId}/v1`;
 }
-
-/** @deprecated Use getFormCacheStorageKey(userId) instead. Kept for migration only. */
-import { safeStorageWrite } from '../utils/storage';
-
-/** AsyncStorage key for the form value cache (versioned for future migrations). */
-export const FORM_CACHE_STORAGE_KEY = '@teachlink/form-cache/v1';
 
 /** Cached entries older than this are pruned on read/write (90 days). */
 export const FORM_CACHE_TTL_MS = 90 * 24 * 60 * 60 * 1000;
@@ -55,7 +49,7 @@ export function pruneExpiredCache(store: FormCacheStore, now = Date.now()): Form
 }
 
 export async function loadFormCache(storageKey: string): Promise<FormCacheStore> {
-  const raw = await AsyncStorage.getItem(storageKey);
+  const raw = await encryptedGetItem(storageKey);
   if (!raw) return {};
   try {
     const parsed = JSON.parse(raw) as FormCacheStore;
@@ -70,9 +64,7 @@ export async function loadFormCache(storageKey: string): Promise<FormCacheStore>
 }
 
 export async function saveFormCache(storageKey: string, store: FormCacheStore): Promise<void> {
-  await AsyncStorage.setItem(storageKey, JSON.stringify(store));
-export async function saveFormCache(store: FormCacheStore): Promise<void> {
-  await safeStorageWrite(FORM_CACHE_STORAGE_KEY, JSON.stringify(store));
+  await encryptedSetItem(storageKey, JSON.stringify(store));
 }
 
 export async function getCachedFieldValue(
@@ -143,7 +135,7 @@ export function getSuggestionForField(
 }
 
 export async function clearFormCache(storageKey: string): Promise<void> {
-  await AsyncStorage.removeItem(storageKey);
+  await encryptedRemoveItem(storageKey);
 }
 
 /** Maps profile/edit labels to shared cache keys. */

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { createJSONStorage, devtools, persist, subscribeWithSelector } from 'zustand/middleware';
 
 import { secureStorageJSONStorage, toUnixMs } from './persistence';
+import { clearFormCache, getFormCacheStorageKey } from '../services/formCache';
 import { sentryContextService } from '../services/sentryContext';
 
 export interface User {
@@ -38,7 +39,7 @@ interface AppState {
 export const useAppStore = create<AppState>()(
   devtools(
     persist(
-      subscribeWithSelector(set => ({
+      subscribeWithSelector((set, get) => ({
         user: null,
         isAuthenticated: false,
         isAuthLoading: false,
@@ -81,6 +82,7 @@ export const useAppStore = create<AppState>()(
         setAuthLoading: isAuthLoading => set({ isAuthLoading }, false, 'setAuthLoading'),
         setAuthError: authError => set({ authError }, false, 'setAuthError'),
         logout: () => {
+          const userId = get().user?.id;
           set(
             {
               user: null,
@@ -98,6 +100,9 @@ export const useAppStore = create<AppState>()(
           // Clear Sentry user scope and reset breadcrumb trail on logout
           sentryContextService.clearUser();
           sentryContextService.resetSession();
+          if (userId) {
+            clearFormCache(getFormCacheStorageKey(userId)).catch(() => {});
+          }
         },
         setLoading: isLoading => set({ isLoading }, false, 'setLoading'),
         setError: error => set({ error }, false, 'setError'),

--- a/src/utils/encryptedStorage.ts
+++ b/src/utils/encryptedStorage.ts
@@ -1,0 +1,87 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Crypto from 'expo-crypto';
+import * as SecureStore from 'expo-secure-store';
+
+// SecureStore accepts alphanumeric, '.', '-', '_'. Prefix 'fce.' scopes keys to form-cache encryption.
+function toSecureStoreKey(storageKey: string): string {
+  return 'fce.' + storageKey.replace(/[^a-zA-Z0-9._-]/g, '.');
+}
+
+function uint8ToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+function base64ToUint8(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+async function getOrCreateAesKey(storageKey: string): Promise<CryptoKey> {
+  const secureKey = toSecureStoreKey(storageKey);
+  const stored = await SecureStore.getItemAsync(secureKey);
+
+  if (stored) {
+    return Crypto.subtle.importKey(
+      'raw',
+      base64ToUint8(stored),
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['encrypt', 'decrypt']
+    );
+  }
+
+  const key = (await Crypto.subtle.generateKey(
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt']
+  )) as CryptoKey;
+
+  const raw = await Crypto.subtle.exportKey('raw', key);
+  await SecureStore.setItemAsync(secureKey, uint8ToBase64(new Uint8Array(raw as ArrayBuffer)));
+
+  return key;
+}
+
+export async function encryptedSetItem(storageKey: string, value: string): Promise<void> {
+  const key = await getOrCreateAesKey(storageKey);
+  const iv = Crypto.getRandomBytes(12);
+  const ciphertext = await Crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    new TextEncoder().encode(value)
+  );
+  const payload = uint8ToBase64(iv) + '.' + uint8ToBase64(new Uint8Array(ciphertext as ArrayBuffer));
+  await AsyncStorage.setItem(storageKey, payload);
+}
+
+export async function encryptedGetItem(storageKey: string): Promise<string | null> {
+  const payload = await AsyncStorage.getItem(storageKey);
+  if (!payload) return null;
+
+  try {
+    const dot = payload.indexOf('.');
+    if (dot === -1) return null;
+
+    const iv = base64ToUint8(payload.slice(0, dot));
+    const ciphertext = base64ToUint8(payload.slice(dot + 1));
+    const key = await getOrCreateAesKey(storageKey);
+    const decrypted = await Crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+
+    return new TextDecoder().decode(decrypted as ArrayBuffer);
+  } catch {
+    return null;
+  }
+}
+
+export async function encryptedRemoveItem(storageKey: string): Promise<void> {
+  await AsyncStorage.removeItem(storageKey);
+  await SecureStore.deleteItemAsync(toSecureStoreKey(storageKey)).catch(() => {});
+}


### PR DESCRIPTION
Closes #587

Form data cached in AsyncStorage — names, addresses, email addresses — was stored as plain JSON, readable by any process or backup tool with access to the device's app storage. This replaces all direct AsyncStorage reads and writes in the form cache service with AES-256-GCM encryption: each storage key gets its own 256-bit symmetric key held in SecureStore (Secure Enclave on iOS, Android Keystore on Android), and encrypted blobs are persisted as `<iv_b64>.<ciphertext_b64>`. Logout now wipes the user's encrypted cache entry so no residue survives a session change.

## Summary
- Created `src/utils/encryptedStorage.ts`: `encryptedSetItem` / `encryptedGetItem` / `encryptedRemoveItem` — AES-256-GCM via `expo-crypto` SubtleCrypto; per-key 256-bit key generated on first write, exported and stored in SecureStore under a `fce.`-prefixed key derived from the storage key; 12-byte random IV prepended to each ciphertext blob; decryption failure returns `null` gracefully
- Rewrote `src/services/formCache.ts`: replaced all `AsyncStorage.{getItem,setItem,removeItem}` calls with the encrypted equivalents; also removed the malformed duplicate `saveFormCache` definition and the dangling deprecated `safeStorageWrite` import that were left by a prior incomplete refactor
- Updated `src/store/index.ts`: changed store creator to `(set, get) =>` so `logout()` can capture `userId` before clearing state; `logout()` now calls `clearFormCache(getFormCacheStorageKey(userId))` to wipe the encrypted cache and its SecureStore key on sign-out
- Added `expo-crypto ~14.0.1` to `package.json` (run `npx expo install expo-crypto` after pulling)
- Updated `src/__tests__/services/formCache.test.ts`: replaced `jest.mock('@react-native-async-storage/async-storage')` with `jest.mock('../../utils/encryptedStorage')` and `jest.mocked()` typed helpers; all existing user-scoped key assertions preserved
- Created `src/__tests__/utils/encryptedStorage.test.ts`: mocks `expo-crypto` with an XOR cipher to verify the stored AsyncStorage value is not plaintext and does not contain raw field values; asserts SecureStore key uses `fce.` prefix; tests graceful null on missing/malformed payload; round-trip test confirms decrypt(encrypt(x)) === x

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore / Refactor (no functional changes)

## Testing Done
- [x] Unit Tests
- [ ] Integration Tests
- [ ] Manual Verification (e.g., iOS/Android UI checks)

## Security Considerations
- [x] Does this store user data securely (e.g., avoiding plain AsyncStorage for sensitive data)? — Form cache is now AES-256-GCM encrypted; key material lives in SecureStore, never in AsyncStorage
- [x] Is token handling secure (no token exposure in logs or UI)? — No tokens involved; decryption errors are silently swallowed without logging raw ciphertext
- [x] Are all user inputs validated? — `SENSITIVE_FIELD_KEYS` guard from the original service is preserved; TTL pruning on read/write unchanged
- [ ] Is deep link handling safe from malicious payloads? — N/A to this change

## Performance Considerations
- [ ] Are React hooks (`useCallback`, `useMemo`) used appropriately to prevent unnecessary renders? — N/A to this change
- [ ] Is `FlatList` optimized (e.g., using `getItemLayout`, `keyExtractor`)? — N/A to this change
- [x] Are asynchronous patterns handled correctly (e.g., `useEffect` cleanup to avoid memory leaks)? — All encrypted storage functions are async; `clearFormCache` in `logout` uses `.catch(() => {})` so a SecureStore failure never blocks sign-out
- [x] Have bundle size impacts been considered? — `expo-crypto` adds no native binary overhead on SDK 54 (it wraps the platform WebCrypto API); `expo-secure-store` was already installed

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [x] My code follows the style guidelines of this project.
- [x] I have updated the documentation accordingly. — N/A; encryption is an internal implementation detail with no public API surface
- [ ] Are there architectural changes? If so, is there an Architectural Decision Record (ADR)? — No architectural changes; all call sites in `useFormCache.ts` are unchanged; the service interface is identical
