### PR TITLE
scrub PII from Sentry breadcrumb request bodies

### DIFF
--- a/src/__tests__/config/logging.test.ts
+++ b/src/__tests__/config/logging.test.ts
@@ -1,0 +1,138 @@
+import * as Sentry from '@sentry/react-native';
+
+jest.mock('@sentry/react-native', () => ({
+  init: jest.fn(),
+  addBreadcrumb: jest.fn(),
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  getAllKeys: jest.fn().mockResolvedValue([]),
+  multiRemove: jest.fn(),
+}));
+
+jest.mock('../../services/sentryContext', () => ({
+  sentryContextService: {
+    getCurrentScreen: jest.fn(() => null),
+    buildCaptureContext: jest.fn(() => ({})),
+    setUser: jest.fn(),
+    clearUser: jest.fn(),
+    resetSession: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/storage', () => ({
+  safeStorageWrite: jest.fn(),
+}));
+
+// Capture the beforeBreadcrumb callback passed to Sentry.init
+let capturedBeforeBreadcrumb: ((b: Sentry.Breadcrumb) => Sentry.Breadcrumb | null) | null = null;
+
+(Sentry.init as jest.Mock).mockImplementation((options: { beforeBreadcrumb?: (b: Sentry.Breadcrumb) => Sentry.Breadcrumb | null }) => {
+  capturedBeforeBreadcrumb = options.beforeBreadcrumb ?? null;
+});
+
+describe('beforeBreadcrumb — PII scrubbing', () => {
+  beforeAll(async () => {
+    // Force production mode so Sentry.init is called
+    jest.resetModules();
+    jest.doMock('@sentry/react-native', () => ({
+      init: (opts: { beforeBreadcrumb?: (b: Sentry.Breadcrumb) => Sentry.Breadcrumb | null }) => {
+        capturedBeforeBreadcrumb = opts.beforeBreadcrumb ?? null;
+      },
+      addBreadcrumb: jest.fn(),
+      captureException: jest.fn(),
+      captureMessage: jest.fn(),
+    }));
+
+    // Patch __DEV__ to false so initializeLogging runs Sentry.init
+    const original = (global as Record<string, unknown>).__DEV__;
+    (global as Record<string, unknown>).__DEV__ = false;
+
+    const { initializeLogging } = await import('../../config/logging');
+    await initializeLogging();
+
+    (global as Record<string, unknown>).__DEV__ = original;
+  });
+
+  function runBreadcrumb(breadcrumb: Sentry.Breadcrumb): Sentry.Breadcrumb | null {
+    if (!capturedBeforeBreadcrumb) throw new Error('beforeBreadcrumb not captured');
+    return capturedBeforeBreadcrumb(breadcrumb);
+  }
+
+  it('redacts password field in xhr breadcrumb body', () => {
+    const result = runBreadcrumb({
+      type: 'xhr',
+      data: { body: { password: 'secret123', courseId: 'abc' } },
+    });
+    expect(result?.data?.body.password).toBe('[REDACTED]');
+    expect(result?.data?.body.courseId).toBe('abc');
+  });
+
+  it('redacts all sensitive fields in request.data', () => {
+    const result = runBreadcrumb({
+      type: 'http',
+      data: {
+        request: {
+          data: {
+            email: 'user@example.com',
+            newPassword: 'hunter2',
+            cardNumber: '4111111111111111',
+            cvv: '123',
+            page: 1,
+          },
+        },
+      },
+    });
+    const d = result?.data?.request?.data;
+    expect(d.email).toBe('[REDACTED]');
+    expect(d.newPassword).toBe('[REDACTED]');
+    expect(d.cardNumber).toBe('[REDACTED]');
+    expect(d.cvv).toBe('[REDACTED]');
+    expect(d.page).toBe(1);
+  });
+
+  it('redacts nested sensitive fields recursively', () => {
+    const result = runBreadcrumb({
+      type: 'xhr',
+      data: {
+        body: {
+          user: { email: 'test@test.com', name: 'Alice' },
+        },
+      },
+    });
+    expect(result?.data?.body.user.email).toBe('[REDACTED]');
+    expect(result?.data?.body.user.name).toBe('Alice');
+  });
+
+  it('does not scrub non-xhr/http breadcrumb types', () => {
+    const result = runBreadcrumb({
+      type: 'navigation',
+      data: { body: { password: 'should-stay' } },
+    });
+    expect(result?.data?.body.password).toBe('should-stay');
+  });
+
+  it('strips token and access_token from URL query params', () => {
+    const result = runBreadcrumb({
+      type: 'http',
+      data: { url: 'https://api.example.com/endpoint?token=abc&access_token=xyz&page=2' },
+    });
+    const url = new URL(result?.data?.url as string);
+    expect(url.searchParams.has('token')).toBe(false);
+    expect(url.searchParams.has('access_token')).toBe(false);
+    expect(url.searchParams.get('page')).toBe('2');
+  });
+
+  it('preserves breadcrumbs with no sensitive data unchanged', () => {
+    const result = runBreadcrumb({
+      type: 'xhr',
+      data: { body: { courseId: '42', page: 3 } },
+    });
+    expect(result?.data?.body).toEqual({ courseId: '42', page: 3 });
+  });
+});

--- a/src/config/logging.ts
+++ b/src/config/logging.ts
@@ -66,6 +66,32 @@ import { safeStorageWrite } from '../utils/storage';
 // Safe check for development environment
 const isDev = typeof __DEV__ !== 'undefined' ? __DEV__ : process.env.NODE_ENV !== 'production';
 
+// ─── BREADCRUMB PII SCRUBBING ─────────────────────────────────────────────
+
+const SENSITIVE_FIELDS = [
+  'password',
+  'oldPassword',
+  'newPassword',
+  'email',
+  'cardNumber',
+  'cvv',
+  'token',
+  'refreshToken',
+] as const;
+
+function scrubSensitiveFields(obj: unknown): unknown {
+  if (typeof obj !== 'object' || obj === null) return obj;
+  if (Array.isArray(obj)) return obj.map(scrubSensitiveFields);
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    result[key] = (SENSITIVE_FIELDS as readonly string[]).includes(key)
+      ? '[REDACTED]'
+      : scrubSensitiveFields(value);
+  }
+  return result;
+}
+
 export enum LogLevel {
   ERROR = 0,
   WARN = 1,
@@ -379,6 +405,19 @@ export async function initializeLogging(): Promise<void> {
               // not a full URL — leave as-is
             }
           }
+
+          // Scrub PII from request bodies captured by xhr/http breadcrumbs
+          if (breadcrumb.type === 'xhr' || breadcrumb.type === 'http') {
+            if (breadcrumb.data?.body !== undefined) {
+              breadcrumb.data.body = scrubSensitiveFields(breadcrumb.data.body);
+            }
+            if (breadcrumb.data?.request?.data !== undefined) {
+              breadcrumb.data.request.data = scrubSensitiveFields(
+                breadcrumb.data.request.data
+              );
+            }
+          }
+
           return breadcrumb;
         },
       });


### PR DESCRIPTION
## Summary
- Added a `SENSITIVE_FIELDS` constant (`password`, `oldPassword`, `newPassword`, `email`, `cardNumber`, `cvv`, `token`, `refreshToken`) in `src/config/logging.ts`
- Implemented a recursive `scrubSensitiveFields` helper that replaces matching keys with `'[REDACTED]'` while preserving all other fields
- Updated `beforeBreadcrumb` to apply scrubbing to `breadcrumb.data.body` and `breadcrumb.data.request.data` for `xhr` and `http` type breadcrumbs only — other breadcrumb types are unaffected
- Existing URL query-param token stripping (`token`, `access_token`) is preserved alongside the new body scrubbing

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore / Refactor (no functional changes)

## Testing Done
- [x] Unit Tests
- [ ] Integration Tests
- [ ] Manual Verification (e.g., iOS/Android UI checks)

## Security Considerations
- [x] Does this store user data securely (e.g., avoiding plain AsyncStorage for sensitive data)? — N/A to this change
- [x] Is token handling secure (no token exposure in logs or UI)? — Tokens and passwords are now `[REDACTED]` in Sentry breadcrumb bodies; URL token stripping retained
- [ ] Are all user inputs validated? — N/A to this change
- [ ] Is deep link handling safe from malicious payloads? — N/A to this change

## Performance Considerations
- [x] Are React hooks (`useCallback`, `useMemo`) used appropriately to prevent unnecessary renders? — N/A to this change
- [ ] Is `FlatList` optimized (e.g., using `getItemLayout`, `keyExtractor`)? — N/A to this change
- [x] Are asynchronous patterns handled correctly (e.g., `useEffect` cleanup to avoid memory leaks)? — `beforeBreadcrumb` is synchronous; no async changes
- [x] Have bundle size impacts been considered? — No new dependencies; recursive scrubber is a small pure function

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide.
- [x] My code follows the style guidelines of this project.
- [ ] I have updated the documentation accordingly. — N/A; no public API surface changed
- [ ] Are there architectural changes? If so, is there an Architectural Decision Record (ADR)? — No architectural changes

Closes #583
