### PR TITLE
fix: stop location watcher and clear state on OS permission revoke (#591)

### DIFF
--- a/src/__tests__/services/locationService.test.ts
+++ b/src/__tests__/services/locationService.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for LocationService OS-level permission-revocation handling (#591).
+ */
+
+import * as Location from 'expo-location';
+import { AppState } from 'react-native';
+
+import { locationService } from '../../services/locationService';
+import { useLocationStore } from '../../store/locationStore';
+
+jest.mock('expo-location', () => ({
+  watchPositionAsync: jest.fn(),
+  getForegroundPermissionsAsync: jest.fn(),
+  requestForegroundPermissionsAsync: jest.fn(),
+  getCurrentPositionAsync: jest.fn(),
+  reverseGeocodeAsync: jest.fn(),
+  Accuracy: { Balanced: 3 },
+}));
+
+jest.mock('../../services/featureCapabilities', () => ({
+  featureCapabilities: { getFeatureInfo: jest.fn() },
+  FeatureStatus: {
+    AVAILABLE: 'available',
+    DEGRADED: 'degraded',
+    UNAVAILABLE: 'unavailable',
+    PERMISSION_DENIED: 'permission_denied',
+    HARDWARE_UNAVAILABLE: 'hardware_unavailable',
+  },
+  FeatureType: { CAMERA: 'camera', PUSH_NOTIFICATIONS: 'push_notifications', LOCATION: 'location' },
+}));
+
+jest.mock('../../store/degradationStore', () => {
+  const state = { setFeatureStatus: jest.fn(), addNotification: jest.fn() };
+  const useDegradationStore: any = jest.fn(() => state);
+  useDegradationStore.getState = jest.fn(() => state);
+  return { useDegradationStore };
+});
+
+jest.mock('../../utils/logger', () => ({
+  appLogger: {
+    infoSync: jest.fn(),
+    warnSync: jest.fn(),
+    errorSync: jest.fn(),
+    debugSync: jest.fn(),
+  },
+}));
+
+const mockedLocation = Location as jest.Mocked<typeof Location>;
+const flushPromises = () => new Promise<void>(resolve => setImmediate(resolve));
+
+const grant = () =>
+  mockedLocation.getForegroundPermissionsAsync.mockResolvedValue({ status: 'granted' } as any);
+const deny = () =>
+  mockedLocation.getForegroundPermissionsAsync.mockResolvedValue({ status: 'denied' } as any);
+
+describe('LocationService permission revoke handling (#591)', () => {
+  let appStateHandler: ((state: string) => void) | undefined;
+  let removeAppStateListener: jest.Mock;
+  let watcherRemove: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    watcherRemove = jest.fn();
+    mockedLocation.watchPositionAsync.mockResolvedValue({ remove: watcherRemove } as any);
+
+    removeAppStateListener = jest.fn();
+    appStateHandler = undefined;
+    jest.spyOn(AppState, 'addEventListener').mockImplementation((event: any, handler: any) => {
+      if (event === 'change') {
+        appStateHandler = handler;
+      }
+      return { remove: removeAppStateListener } as any;
+    });
+
+    // Start each test from a clean singleton + store.
+    locationService.reset();
+    useLocationStore.getState().clearLocation();
+    useLocationStore.getState().setPermissionGranted(false);
+  });
+
+  afterEach(() => {
+    locationService.reset();
+  });
+
+  it('does not start a watcher when permission was never granted', async () => {
+    deny();
+
+    const started = await locationService.startWatching();
+
+    expect(started).toBe(false);
+    expect(mockedLocation.watchPositionAsync).not.toHaveBeenCalled();
+    expect(useLocationStore.getState().permissionGranted).toBe(false);
+  });
+
+  it('registers a watcher and marks permission granted after approval', async () => {
+    grant();
+
+    const started = await locationService.startWatching();
+
+    expect(started).toBe(true);
+    expect(mockedLocation.watchPositionAsync).toHaveBeenCalledTimes(1);
+    expect(useLocationStore.getState().permissionGranted).toBe(true);
+  });
+
+  it('does not register a duplicate watcher when called twice', async () => {
+    grant();
+
+    await locationService.startWatching();
+    await locationService.startWatching();
+
+    expect(mockedLocation.watchPositionAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('stores coordinates emitted by the watcher', async () => {
+    grant();
+    await locationService.startWatching();
+
+    const callback = mockedLocation.watchPositionAsync.mock.calls[0][1] as (loc: any) => void;
+    callback({ coords: { latitude: 6.5244, longitude: 3.3792, accuracy: 10 } });
+
+    expect(useLocationStore.getState().coordinates).toEqual(
+      expect.objectContaining({ latitude: 6.5244, longitude: 3.3792, accuracy: 10 })
+    );
+  });
+
+  it('stops the watcher and clears location when permission is revoked', async () => {
+    grant();
+    await locationService.startWatching();
+
+    const callback = mockedLocation.watchPositionAsync.mock.calls[0][1] as (loc: any) => void;
+    callback({ coords: { latitude: 6.5244, longitude: 3.3792, accuracy: 10 } });
+    expect(useLocationStore.getState().coordinates).not.toBeNull();
+
+    // User revokes permission at the OS level.
+    deny();
+    await locationService.reconcilePermission();
+
+    expect(watcherRemove).toHaveBeenCalledTimes(1);
+    expect(useLocationStore.getState().coordinates).toBeNull();
+    expect(useLocationStore.getState().permissionGranted).toBe(false);
+  });
+
+  it('detects revoke when the app returns to the foreground (AppState)', async () => {
+    grant();
+    await locationService.startWatching();
+    expect(appStateHandler).toBeDefined();
+
+    deny();
+    appStateHandler?.('active');
+    await flushPromises();
+
+    expect(watcherRemove).toHaveBeenCalledTimes(1);
+    expect(useLocationStore.getState().coordinates).toBeNull();
+    expect(useLocationStore.getState().permissionGranted).toBe(false);
+  });
+
+  it('cleanup() removes the watcher and AppState listener', async () => {
+    grant();
+    await locationService.startWatching();
+
+    locationService.cleanup();
+
+    expect(watcherRemove).toHaveBeenCalledTimes(1);
+    expect(removeAppStateListener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/locationService.ts
+++ b/src/services/locationService.ts
@@ -8,13 +8,28 @@
  *
  * Gracefully degrades to manual entry if GPS unavailable
  * No errors thrown - always falls back to manual entry
+ *
+ * Security (#591): the service also monitors for OS-level location permission
+ * revocation. When a user turns off location access from Settings while the app
+ * is running, the active position watcher is stopped, cached/stored coordinates
+ * are cleared, and permission state is flipped to false so no stale location
+ * data is ever served.
  */
 
+import { AppState, AppStateStatus } from 'react-native';
 import * as Location from 'expo-location';
 
 import { featureCapabilities, FeatureStatus, FeatureType } from './featureCapabilities';
 import { useDegradationStore } from '../store/degradationStore';
+import { useLocationStore } from '../store/locationStore';
 import { appLogger } from '../utils/logger';
+
+/**
+ * How often (ms) to re-check OS permission while a watcher is active. Combined
+ * with the AppState 'active' listener this guarantees revocation is detected
+ * within a few seconds even if the app is never backgrounded.
+ */
+const PERMISSION_POLL_INTERVAL_MS = 3000;
 
 export enum LocationSourceType {
   GPS = 'gps',
@@ -36,6 +51,12 @@ class LocationService {
   private static instance: LocationService;
   private cachedLocation: LocationData | null = null;
   private locationPermissionStatus: Location.PermissionStatus | null = null;
+
+  // #591 — position watcher + permission-revoke monitoring
+  private watchSubscription: Location.LocationSubscription | null = null;
+  private appStateSubscription: { remove: () => void } | null = null;
+  private permissionPollTimer: ReturnType<typeof setInterval> | null = null;
+  private lastPermissionGranted = false;
 
   private constructor() {}
 
@@ -99,7 +120,7 @@ class LocationService {
   public async getCurrentLocation(): Promise<LocationData | null> {
     try {
       // Check permission
-      const hasPermission = this.locationPermissionStatus === 'granted' || await this.checkPermission();
+      const hasPermission = this.locationPermissionStatus === 'granted' || (await this.checkPermission());
       if (!hasPermission) {
         appLogger.infoSync('[LocationService] Location permission not granted - GPS unavailable');
         featureCapabilities.getFeatureInfo(FeatureType.LOCATION);
@@ -261,6 +282,184 @@ class LocationService {
       default:
         return 'Location unavailable - please enter manually';
     }
+  }
+
+  // ─── #591: position watcher + OS-level permission-revoke handling ──────────
+
+  /**
+   * Start a continuous position watcher and begin monitoring for OS-level
+   * permission revocation. No-op (returns false) if permission is not granted;
+   * safe to call repeatedly (will not register duplicate watchers).
+   */
+  public async startWatching(
+    onUpdate?: (location: LocationData) => void,
+    options?: Location.LocationOptions
+  ): Promise<boolean> {
+    const hasPermission = await this.checkPermission();
+    if (!hasPermission) {
+      appLogger.infoSync('[LocationService] Cannot start watcher - permission not granted');
+      this.setStorePermission(false);
+      this.lastPermissionGranted = false;
+      return false;
+    }
+
+    // Prevent duplicate watchers.
+    if (this.watchSubscription) {
+      appLogger.infoSync('[LocationService] Watcher already active - skipping duplicate registration');
+      return true;
+    }
+
+    this.watchSubscription = await Location.watchPositionAsync(
+      options ?? {
+        accuracy: Location.Accuracy.Balanced,
+        timeInterval: 5000,
+        distanceInterval: 0,
+      },
+      location => {
+        const locationData: LocationData = {
+          latitude: location.coords.latitude,
+          longitude: location.coords.longitude,
+          accuracy: location.coords.accuracy || undefined,
+          source: LocationSourceType.GPS,
+          obtainedAt: new Date().toISOString(),
+        };
+
+        this.cachedLocation = locationData;
+        useLocationStore.getState().setCoordinates({
+          latitude: locationData.latitude as number,
+          longitude: locationData.longitude as number,
+          accuracy: locationData.accuracy,
+          obtainedAt: locationData.obtainedAt,
+        });
+
+        onUpdate?.(locationData);
+      }
+    );
+
+    this.lastPermissionGranted = true;
+    this.setStorePermission(true);
+    this.startPermissionMonitoring();
+
+    appLogger.infoSync('[LocationService] Position watcher started');
+    return true;
+  }
+
+  /**
+   * Stop the active position watcher (if any) and release its native subscription.
+   */
+  public stopWatching(): void {
+    if (this.watchSubscription) {
+      this.watchSubscription.remove();
+      this.watchSubscription = null;
+      appLogger.infoSync('[LocationService] Position watcher stopped');
+    }
+  }
+
+  /**
+   * Re-check OS location permission and react to a granted -> denied transition
+   * by tearing down the watcher and purging all cached/stored coordinates.
+   * Exposed publicly so it can be unit-tested and triggered on demand.
+   */
+  public async reconcilePermission(): Promise<void> {
+    let granted = false;
+    try {
+      const { status } = await Location.getForegroundPermissionsAsync();
+      this.locationPermissionStatus = status;
+      granted = status === 'granted';
+    } catch (error) {
+      appLogger.errorSync('[LocationService] Error while re-checking permission', error instanceof Error ? error : new Error(String(error)));
+      return;
+    }
+
+    if (this.lastPermissionGranted && !granted) {
+      this.handlePermissionRevoked();
+    }
+
+    this.lastPermissionGranted = granted;
+  }
+
+  /**
+   * Dispose of the watcher and all listeners. Call on logout / teardown.
+   */
+  public cleanup(): void {
+    this.stopWatching();
+    this.stopPermissionMonitoring();
+    this.lastPermissionGranted = false;
+  }
+
+  /**
+   * Full reset: cleanup + clear cached and stored coordinates. Useful for tests
+   * and for a hard re-initialisation of the service.
+   */
+  public reset(): void {
+    this.cleanup();
+    this.clearCachedLocation();
+    const store = useLocationStore.getState();
+    store.clearLocation();
+    store.setPermissionGranted(false);
+  }
+
+  private startPermissionMonitoring(): void {
+    if (!this.appStateSubscription) {
+      this.appStateSubscription = AppState.addEventListener('change', this.handleAppStateChange);
+    }
+    if (!this.permissionPollTimer) {
+      this.permissionPollTimer = setInterval(() => {
+        void this.reconcilePermission();
+      }, PERMISSION_POLL_INTERVAL_MS);
+    }
+  }
+
+  private stopPermissionMonitoring(): void {
+    if (this.appStateSubscription) {
+      this.appStateSubscription.remove();
+      this.appStateSubscription = null;
+    }
+    if (this.permissionPollTimer) {
+      clearInterval(this.permissionPollTimer);
+      this.permissionPollTimer = null;
+    }
+  }
+
+  private handleAppStateChange = (nextState: AppStateStatus): void => {
+    if (nextState === 'active') {
+      void this.reconcilePermission();
+    }
+  };
+
+  /**
+   * Tear down the watcher, purge cached + stored coordinates, flip permission
+   * state, notify degradation store, and record the event.
+   */
+  private handlePermissionRevoked(): void {
+    appLogger.warnSync('[LocationService] Location permission revoked at OS level - cleaning up');
+
+    this.stopWatching();
+    this.clearCachedLocation();
+
+    const locationStore = useLocationStore.getState();
+    locationStore.clearLocation();
+    locationStore.setPermissionGranted(false);
+
+    try {
+      // Use getState() (not the hook) because this runs outside React.
+      const degradationStore = useDegradationStore.getState();
+      degradationStore.setFeatureStatus(FeatureType.LOCATION, FeatureStatus.DEGRADED);
+      degradationStore.addNotification({
+        feature: FeatureType.LOCATION,
+        status: FeatureStatus.DEGRADED,
+        message: 'Location permission was turned off. You can manually enter your location instead.',
+      });
+    } catch (error) {
+      appLogger.errorSync('[LocationService] Failed to update degradation store after revoke', error instanceof Error ? error : new Error(String(error)));
+    }
+
+    // The watcher is gone; stop monitoring until watching restarts.
+    this.stopPermissionMonitoring();
+  }
+
+  private setStorePermission(granted: boolean): void {
+    useLocationStore.getState().setPermissionGranted(granted);
   }
 }
 

--- a/src/store/locationStore.ts
+++ b/src/store/locationStore.ts
@@ -1,0 +1,37 @@
+/**
+ * Location state store (#591)
+ *
+ * Centralised, in-memory store for the device's current coordinates and
+ * OS-level location permission state. Kept intentionally un-persisted so that
+ * coordinates never survive an app restart (privacy) and are always re-derived
+ * from a live, permission-checked GPS read.
+ *
+ * Access outside React (e.g. from services) via `useLocationStore.getState()`.
+ */
+
+import { create } from 'zustand';
+
+export interface LocationCoordinates {
+  latitude: number;
+  longitude: number;
+  accuracy?: number;
+  obtainedAt: string; // ISO timestamp
+}
+
+interface LocationState {
+  coordinates: LocationCoordinates | null;
+  permissionGranted: boolean;
+
+  setCoordinates: (coordinates: LocationCoordinates | null) => void;
+  setPermissionGranted: (granted: boolean) => void;
+  clearLocation: () => void;
+}
+
+export const useLocationStore = create<LocationState>(set => ({
+  coordinates: null,
+  permissionGranted: false,
+
+  setCoordinates: coordinates => set({ coordinates }),
+  setPermissionGranted: permissionGranted => set({ permissionGranted }),
+  clearLocation: () => set({ coordinates: null }),
+}));


### PR DESCRIPTION
## What this fixes

`src/services/locationService.ts` could keep an active position watcher running after the user revoked location permission at the OS level (iOS 14+/Android), continuing to serve stale coordinates. This adds OS-level permission-revoke detection and cleanup.

## Changes

- **`src/store/locationStore.ts` (new)** — dedicated in-memory Zustand store for live `coordinates` + `permissionGranted`, with `setCoordinates()`, `setPermissionGranted()`, and `clearLocation()`. Not persisted, so coordinates never survive a restart.
- **`src/services/locationService.ts`** — adds a `watchPositionAsync`-based watcher (`startWatching`/`stopWatching`) and permission-revoke monitoring:
  - An `AppState` "active" listener re-checks permission when the app returns from Settings.
  - A 3s poll while watching guarantees detection within the 5s acceptance window even without backgrounding.
  - On a granted → denied transition: removes the watcher subscription, clears cached + stored coordinates, sets `permissionGranted: false`, updates the degradation store, and logs via `appLogger`.
  - Adds `cleanup()` / `reset()` for safe teardown of watchers and listeners.
- **`src/__tests__/services/locationService.test.ts` (new)** — unit tests mocking a mid-session permission revoke.

## Acceptance criteria

- ✅ Position watcher stops within 5s of permission being revoked (AppState + 3s poll).
- ✅ `locationStore` coordinates cleared on revoke.
- ✅ No stale location data served after revoke (cache + store both purged).
- ✅ Unit test confirms watcher removal and store cleanup on permission change.

Closes #591