### PR TITLE
feat: add haptic feedback for quiz answers and achievement unlocks

### DIFF
--- a/src/store/achievementStore.ts
+++ b/src/store/achievementStore.ts
@@ -11,6 +11,7 @@ import { useReviewStore } from './reviewStore';
 import apiService from '../services/api';
 import { inAppReviewService, ReviewTrigger } from '../services/inAppReview';
 import { appLogger } from '../utils/logger';
+import { achievementHaptic } from '../utils/quizHaptics';
 
 const triggerAchievementReview = () => {
   const { incrementAchievementsUnlocked, getMetrics, recordReviewRequest } = useReviewStore.getState();
@@ -317,6 +318,8 @@ export const useAchievementStore = create<AchievementState>()(
           achievementProgress: snapshotAchievementProgress(updatedAchievements),
           unlockedCount: updatedAchievements.filter(a => !a.isLocked).length,
         });
+        // #835: success haptic when an achievement unlocks.
+        void achievementHaptic();
         setTimeout(triggerAchievementReview, 500);
 
         try {

--- a/src/store/quizStore.ts
+++ b/src/store/quizStore.ts
@@ -4,6 +4,7 @@ import { create } from 'zustand';
 import { isRecord } from './persistence';
 import { Quiz, QuizProgress } from '../types/course';
 import logger from '../utils/logger';
+import { quizAnswerHaptic } from '../utils/quizHaptics';
 
 const QUIZ_SESSION_KEY = '@teachlink_quiz_session';
 const QUIZ_PROGRESS_KEY = '@teachlink_quiz_progress';
@@ -177,6 +178,9 @@ export const useQuizStore = create<QuizState>((set, get) => ({
   },
 
   selectAnswer: (questionId: string, answer: string | number, isMultiSelect = false) => {
+    // #835: tactile confirmation on every answer selection.
+    void quizAnswerHaptic();
+
     const { session } = get();
     let updatedAnswer: string | number | (string | number)[];
 

--- a/src/utils/quizHaptics.ts
+++ b/src/utils/quizHaptics.ts
@@ -1,0 +1,39 @@
+import {
+  ImpactFeedbackStyle,
+  NotificationFeedbackType,
+  impactAsync,
+  notificationAsync,
+} from 'expo-haptics';
+import { AccessibilityInfo } from 'react-native';
+
+/**
+ * #835: haptic feedback for quiz answers and achievement unlocks.
+ *
+ * Both helpers respect the OS "Reduce Motion" accessibility setting — when it
+ * is enabled, no haptic is triggered. Failures are swallowed so haptics never
+ * interrupt the learning flow.
+ */
+
+async function reduceMotionEnabled(): Promise<boolean> {
+  try {
+    return await AccessibilityInfo.isReduceMotionEnabled();
+  } catch {
+    return false;
+  }
+}
+
+/** Medium impact when a quiz answer is selected. */
+export async function quizAnswerHaptic(): Promise<void> {
+  if (await reduceMotionEnabled()) return;
+  impactAsync(ImpactFeedbackStyle.Medium).catch(() => {
+    // Ignore haptic failures silently.
+  });
+}
+
+/** Success notification when an achievement is unlocked. */
+export async function achievementHaptic(): Promise<void> {
+  if (await reduceMotionEnabled()) return;
+  notificationAsync(NotificationFeedbackType.Success).catch(() => {
+    // Ignore haptic failures silently.
+  });
+}


### PR DESCRIPTION
closes #835

## Overview
Quiz answer submissions and achievement unlocks had no haptic feedback. This adds tactile confirmation for both, while respecting the OS **Reduce Motion** accessibility setting.

## Changes
- **`src/utils/quizHaptics.ts`** (new): small helper with `quizAnswerHaptic()` (medium impact) and `achievementHaptic()` (success notification). Both first check `AccessibilityInfo.isReduceMotionEnabled()` and no-op when Reduce Motion is on; haptic failures are swallowed silently.
- **`src/store/quizStore.ts`**: fire `quizAnswerHaptic()` at the start of `selectAnswer`, so every answer selection gives feedback.
- **`src/store/achievementStore.ts`**: fire `achievementHaptic()` in `unlockAchievement` when an achievement actually unlocks.

## Acceptance criteria
- Haptic fires on every quiz answer selection ✅
- Achievement unlock triggers a success haptic ✅
- Haptics respect the OS Reduce Motion setting ✅

Kept intentionally small — reuses the already-installed `expo-haptics` and hooks into the existing store actions. Per the requested scope, I did not run tests or a build locally.
