### PR TITLE
fix: align empty restore-purchases message with expected copy

### DIFF
--- a/src/hooks/useInAppPurchase.ts
+++ b/src/hooks/useInAppPurchase.ts
@@ -172,7 +172,7 @@ export const useInAppPurchase = (): UseInAppPurchase => {
       if (restored.length === 0) {
         return {
           count: 0,
-          message: 'No previous purchases found for this account.',
+          message: 'No purchases found to restore.',
         };
       }
       return {


### PR DESCRIPTION
closes #834

## Overview
Ensures the "Restore Purchases" flow behaves per the acceptance criteria.

While reviewing, the restore button is already connected: both `SubscriptionManager` and `PaymentHistory` call `restorePurchases()` from `useInAppPurchase`, which invokes `mobilePayments.restorePurchases()`, refreshes the subscription tier (so restored items unlock immediately), refreshes history, and surfaces the result in an alert.

The one detail not matching the acceptance criteria was the empty-restore copy. This aligns it:

- **`src/hooks/useInAppPurchase.ts`**: empty restore now returns `"No purchases found to restore."` (was `"No previous purchases found for this account."`), which both the paywall and payment-history restore buttons display.

## Acceptance criteria
- Restore Purchases button calls the real API ✅ (already wired)
- Restored items unlock immediately after restore ✅ (tier + history refresh in the hook)
- Empty restore shows "No purchases found to restore" ✅ (this change)

Per the requested scope, I did not run tests or a build locally.
