### PR TITLE
feat: generate certificate of completion on course completion

### DIFF
--- a/src/components/mobile/MobileCourseViewer.tsx
+++ b/src/components/mobile/MobileCourseViewer.tsx
@@ -21,6 +21,7 @@ import { useCourseProgress, useDynamicFontSize } from '../../hooks';
 import { useAnalytics } from '../../hooks/useAnalytics';
 import { useInAppReview, useReviewMetrics } from '../../hooks/useInAppReview';
 import { usePrefetchImages } from '../../hooks/usePrefetchImages';
+import certificateService from '../../services/certificateService';
 import { ReviewTrigger } from '../../services/inAppReview';
 import { useReviewStore } from '../../store/reviewStore';
 import { Course, Lesson, Note } from '../../types/course';
@@ -246,6 +247,9 @@ const MobileCourseViewer = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [course.id]);
 
+  // #833: ensure a certificate is only requested once per completion.
+  const certificateRequestedRef = useRef(false);
+
   // Track course completion
   useEffect(() => {
     if (progress) {
@@ -256,6 +260,12 @@ const MobileCourseViewer = ({
           courseTitle: course.title,
           progress: overallProgress,
         });
+
+        // #833: generate the certificate of completion for the finished course.
+        if (!certificateRequestedRef.current) {
+          certificateRequestedRef.current = true;
+          void certificateService.generateCertificate(course.id, course.title);
+        }
 
         // Track and request review
         trackCourseComplete();

--- a/src/services/certificateService.ts
+++ b/src/services/certificateService.ts
@@ -1,0 +1,43 @@
+import { apiService } from './api';
+import { logger } from '../utils/logger';
+
+export interface Certificate {
+  id: string;
+  courseId: string;
+  courseTitle: string;
+  /** URL of the generated certificate (PDF or image). */
+  url: string;
+  issuedAt: string;
+}
+
+/**
+ * #833: request a certificate of completion from the backend once a course is
+ * completed. Best-effort — failures are logged and swallowed so certificate
+ * generation never blocks the course-completion flow.
+ */
+export const certificateService = {
+  async generateCertificate(
+    courseId: string,
+    courseTitle?: string
+  ): Promise<Certificate | null> {
+    try {
+      const response: unknown = await apiService.post('/api/certificates/generate', {
+        courseId,
+        courseTitle,
+      });
+      // apiService.post returns the raw axios response; unwrap .data when present.
+      const certificate = (
+        response && typeof response === 'object' && 'data' in response
+          ? (response as { data: unknown }).data
+          : response
+      ) as Certificate;
+      logger.info('Certificate generated', { courseId });
+      return certificate;
+    } catch (error) {
+      logger.warn('Certificate generation failed', { courseId, error: String(error) });
+      return null;
+    }
+  },
+};
+
+export default certificateService;


### PR DESCRIPTION
closes #833

## Overview
When a user completed all lessons in a course, `COURSE_COMPLETED` was tracked but no certificate was ever requested. This wires certificate generation into the completion flow.

## Changes
- **`src/services/certificateService.ts`** (new): `certificateService.generateCertificate(courseId, courseTitle?)` requests a certificate of completion from the backend (`POST /api/certificates/generate`). It's best-effort — failures are logged and swallowed so certificate generation never blocks the completion flow.
- **`src/components/mobile/MobileCourseViewer.tsx`**: when a course reaches 100% (right where `COURSE_COMPLETED` is tracked), it now calls `certificateService.generateCertificate(course.id, course.title)`. A `certificateRequestedRef` guard ensures the certificate is requested only once per completion, avoiding duplicates from re-renders.

## Acceptance criteria
- Certificate generated on course completion ✅ (requested immediately when the `COURSE_COMPLETED` condition fires)
- Best-effort and non-blocking ✅

## Scope note
Kept intentionally small per the requested scope — this covers the core gap (certificate generation was never triggered). The dedicated `CertificateScreen` with the in-app preview and share button is a natural follow-up on top of this service. I did not run tests or a build locally.
