### PR TITLE
fix(626): stabilize SettingRow onPress/right/icon props to prevent un…

### DIFF
--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -16,11 +17,11 @@ const SettingsScreen = () => {
   const router = useRouter();
   const { logout } = useAppStore();
 
-  const handleSignOut = async () => {
+  const handleSignOut = useCallback(async () => {
     await mobileAuthService.logout();
     logout();
     router.replace('/');
-  };
+  }, [logout, router]);
 
   return (
     <SafeAreaView style={{ flex: 1 }} edges={['top']}>

--- a/src/components/mobile/MobileSettings.tsx
+++ b/src/components/mobile/MobileSettings.tsx
@@ -88,6 +88,30 @@ const SettingRow = memo(function SettingRow({
 });
 
 // ─────────────────────────────────────────────────────────────
+// Stable icon elements (created once to preserve referential
+// identity across renders — enables React.memo on SettingRow)
+// ─────────────────────────────────────────────────────────────
+
+const ICON_EYE = <Eye size={18} color="#6366f1" />;
+const ICON_LOCK = <Lock size={18} color="#10b981" />;
+const ICON_FINGERPRINT = <FingerprintPattern size={18} color="#06b6d4" />;
+const ICON_USER = <User size={18} />;
+const ICON_CREDIT_CARD_YELLOW = <CreditCard size={18} color="#f59e0b" />;
+const ICON_CREDIT_CARD_GREEN = <CreditCard size={18} color="#10b981" />;
+const ICON_SUN = <Sun size={18} />;
+const ICON_DATABASE = <Database size={18} color="#eab308" />;
+const ICON_BAR_CHART = <BarChart2 size={18} />;
+const ICON_TRASH_RED = <Trash2 size={18} color="red" />;
+const ICON_DOWNLOAD_INDIGO = <Download size={18} color="#6366f1" />;
+const ICON_WIFI = <Wifi size={18} />;
+const ICON_DOWNLOAD = <Download size={18} />;
+const ICON_REFRESH = <RefreshCw size={18} />;
+const ICON_ZAP = <Zap size={18} color="#06b6d4" />;
+const ICON_SHIELD = <ShieldAlert size={18} color="#ef4444" />;
+const ICON_LOGOUT_RED = <LogOut size={18} color="red" />;
+const ICON_ALERT = <AlertTriangle size={18} color="#dc2626" />;
+
+// ─────────────────────────────────────────────────────────────
 // Options
 // ─────────────────────────────────────────────────────────────
 
@@ -344,58 +368,125 @@ export const MobileSettings = ({ onSignOut, onChangePassword, onLinkedAccounts }
     );
   }, [performReauthCheck]);
 
+  // Wrap parent-provided callbacks so they are stable references
+  const handleChangePassword = useCallback(() => {
+    onChangePassword?.();
+  }, [onChangePassword]);
+
+  const handleLinkedAccounts = useCallback(() => {
+    onLinkedAccounts?.();
+  }, [onLinkedAccounts]);
+
+  // ── Memoised right elements (stable references) ────────
+  const profileVisibilityRight = useMemo(
+    () => (
+      <SettingsPicker
+        label="Visibility"
+        value={profileVisibility}
+        options={VISIBILITY_OPTIONS}
+        onValueChange={setProfileVisibility}
+      />
+    ),
+    [profileVisibility, setProfileVisibility]
+  );
+
+  const twoFactorRight = useMemo(
+    () => <NativeToggle value={twoFactorEnabled} onValueChange={setTwoFactorEnabled} />,
+    [twoFactorEnabled, setTwoFactorEnabled]
+  );
+
+  const biometricIcon = useMemo(
+    () => (biometricLoading ? <ActivityIndicator /> : ICON_FINGERPRINT),
+    [biometricLoading]
+  );
+
+  const biometricRight = useMemo(
+    () => (
+      <NativeToggle
+        value={biometricEnabled}
+        onValueChange={handleBiometricToggle}
+        disabled={biometricLoading}
+      />
+    ),
+    [biometricEnabled, handleBiometricToggle, biometricLoading]
+  );
+
+  const themeRight = useMemo(
+    () => (
+      <SettingsPicker
+        label="Theme"
+        value={theme}
+        options={THEME_OPTIONS}
+        onValueChange={setTheme}
+      />
+    ),
+    [theme, setTheme]
+  );
+
+  const dataSaverRight = useMemo(
+    () => (
+      <NativeToggle value={dataSaverEnabled} onValueChange={setDataSaverEnabled} />
+    ),
+    [dataSaverEnabled, setDataSaverEnabled]
+  );
+
+  const analyticsRight = useMemo(
+    () => <NativeToggle value={analyticsEnabled} onValueChange={setAnalyticsEnabled} />,
+    [analyticsEnabled, setAnalyticsEnabled]
+  );
+
+  const wifiOnlyRight = useMemo(
+    () => (
+      <NativeToggle value={downloadOverWifiOnly} onValueChange={setDownloadOverWifiOnly} />
+    ),
+    [downloadOverWifiOnly, setDownloadOverWifiOnly]
+  );
+
+  const qualityRight = useMemo(
+    () => (
+      <SettingsPicker
+        label="Quality"
+        value={downloadQuality}
+        options={QUALITY_OPTIONS}
+        onValueChange={setDownloadQuality}
+      />
+    ),
+    [downloadQuality, setDownloadQuality]
+  );
+
   return (
     <ScrollView className="flex-1 bg-gray-50 dark:bg-gray-900">
       {/* ── ESSENTIAL: ACCOUNT ─────────────────────────────── */}
       <SettingsSection title="Account">
         <SettingRow
-          icon={<Eye size={18} color="#6366f1" />}
+          icon={ICON_EYE}
           label="Profile Visibility"
-          right={
-            <SettingsPicker
-              label="Visibility"
-              value={profileVisibility}
-              options={VISIBILITY_OPTIONS}
-              onValueChange={setProfileVisibility}
-            />
-          }
+          right={profileVisibilityRight}
         />
 
         <SettingRow
-          icon={<Lock size={18} color="#10b981" />}
+          icon={ICON_LOCK}
           label="Two-Factor Auth"
-          right={<NativeToggle value={twoFactorEnabled} onValueChange={setTwoFactorEnabled} />}
+          right={twoFactorRight}
         />
 
         {biometricAvailable && (
           <SettingRow
-            icon={
-              biometricLoading ? (
-                <ActivityIndicator />
-              ) : (
-                <FingerprintPattern size={18} color="#06b6d4" />
-              )
-            }
+            icon={biometricIcon}
             label="Biometric Login"
             description={biometricEnabled ? 'Enabled' : 'Disabled'}
-            right={
-              <NativeToggle
-                value={biometricEnabled}
-                onValueChange={handleBiometricToggle}
-                disabled={biometricLoading}
-              />
-            }
+            right={biometricRight}
           />
         )}
 
-        <SettingRow icon={<User size={18} />} label="Change Password" onPress={onChangePassword} />
+        <SettingRow icon={ICON_USER} label="Change Password" onPress={handleChangePassword} />
         <SettingRow
-          icon={<CreditCard size={18} color="#f59e0b" />}
+          icon={ICON_CREDIT_CARD_YELLOW}
           label="Change Payment Method"
           onPress={handleChangePaymentMethod}
         />
         <SettingRow
-          icon={<CreditCard size={18} color="#10b981" />}
+          icon={ICON_CREDIT_CARD_GREEN}
           label="View Full Card Number"
           onPress={handleViewFullCardNumber}
         />
@@ -404,23 +495,16 @@ export const MobileSettings = ({ onSignOut, onChangePassword, onLinkedAccounts }
       {/* ── ESSENTIAL: APP ─────────────────────────────────── */}
       <SettingsSection title="App">
         <SettingRow
-          icon={<Sun size={18} />}
+          icon={ICON_SUN}
           label="Theme"
-          right={
-            <SettingsPicker
-              label="Theme"
-              value={theme}
-              options={THEME_OPTIONS}
-              onValueChange={setTheme}
-            />
-          }
+          right={themeRight}
         />
 
         <SettingRow
-          icon={<Database size={18} color="#eab308" />}
+          icon={ICON_DATABASE}
           label="Data Saver"
           description="Reduces bandwidth by disabling prefetch and lowering image quality"
-          right={<NativeToggle value={dataSaverEnabled} onValueChange={setDataSaverEnabled} />}
+          right={dataSaverRight}
         />
       </SettingsSection>
 
@@ -432,13 +516,13 @@ export const MobileSettings = ({ onSignOut, onChangePassword, onLinkedAccounts }
           {/* PRIVACY */}
           <SettingsSection title="Privacy">
             <SettingRow
-              icon={<BarChart2 size={18} />}
+              icon={ICON_BAR_CHART}
               label="Analytics"
-              right={<NativeToggle value={analyticsEnabled} onValueChange={setAnalyticsEnabled} />}
+              right={analyticsRight}
             />
 
             <SettingRow
-              icon={<Trash2 size={18} color="red" />}
+              icon={ICON_TRASH_RED}
               label="Clear Cached Form Data"
               description="Remove saved autofill values from this device"
               onPress={handleClearFormCache}
@@ -446,7 +530,7 @@ export const MobileSettings = ({ onSignOut, onChangePassword, onLinkedAccounts }
             />
 
             <SettingRow
-              icon={<Download size={18} color="#6366f1" />}
+              icon={ICON_DOWNLOAD_INDIGO}
               label="Export Personal Data"
               description="Export your account details and learning progress"
               onPress={handleExportData}
@@ -456,31 +540,19 @@ export const MobileSettings = ({ onSignOut, onChangePassword, onLinkedAccounts }
           {/* DOWNLOADS */}
           <SettingsSection title="Downloads">
             <SettingRow
-              icon={<Wifi size={18} />}
+              icon={ICON_WIFI}
               label="WiFi Only"
-              right={
-                <NativeToggle
-                  value={downloadOverWifiOnly}
-                  onValueChange={setDownloadOverWifiOnly}
-                />
-              }
+              right={wifiOnlyRight}
             />
 
             <SettingRow
-              icon={<Download size={18} />}
+              icon={ICON_DOWNLOAD}
               label="Quality"
-              right={
-                <SettingsPicker
-                  label="Quality"
-                  value={downloadQuality}
-                  options={QUALITY_OPTIONS}
-                  onValueChange={setDownloadQuality}
-                />
-              }
+              right={qualityRight}
             />
 
             <SettingRow
-              icon={<Trash2 size={18} color="red" />}
+              icon={ICON_TRASH_RED}
               label="Clear Downloads"
               onPress={handleClearDownloads}
               destructive
@@ -490,7 +562,7 @@ export const MobileSettings = ({ onSignOut, onChangePassword, onLinkedAccounts }
           {/* SYNC */}
           <SettingsSection title="Sync">
             <SettingRow
-              icon={<RefreshCw size={18} />}
+              icon={ICON_REFRESH}
               label="Manual Sync"
               onPress={handleManualSync}
             />
@@ -499,13 +571,13 @@ export const MobileSettings = ({ onSignOut, onChangePassword, onLinkedAccounts }
           {/* PERFORMANCE & UTILITIES */}
           <SettingsSection title="Performance & Utilities">
             <SettingRow
-              icon={<Zap size={18} color="#06b6d4" />}
+              icon={ICON_ZAP}
               label="Clipboard Optimizer"
               description="Test & profile asynchronous clipboard operations"
             />
 
             <SettingRow
-              icon={<ShieldAlert size={18} color="#ef4444" />}
+              icon={ICON_SHIELD}
               label="Admin Dashboard"
               description="Access systems health & performance diagnostics"
               onPress={handleAdminDashboard}
@@ -517,13 +589,13 @@ export const MobileSettings = ({ onSignOut, onChangePassword, onLinkedAccounts }
       {/* ── ESSENTIAL: ACCOUNT ACTIONS ─────────────────────── */}
       <SettingsSection title="Account Actions">
         <SettingRow
-          icon={<LogOut size={18} color="red" />}
+          icon={ICON_LOGOUT_RED}
           label="Sign Out"
           onPress={handleSignOut}
           destructive
         />
         <SettingRow
-          icon={<AlertTriangle size={18} color="#dc2626" />}
+          icon={ICON_ALERT}
           label="Delete Account"
           description="Permanently delete your account and all data"
           onPress={handleDeleteAccount}

--- a/src/components/mobile/NotificationSettings.tsx
+++ b/src/components/mobile/NotificationSettings.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, ChevronUp } from 'lucide-react-native';
-import React, { memo, useState } from 'react';
+import React, { memo, useCallback, useState } from 'react';
 import {
     ScrollView,
     Switch,
@@ -62,28 +62,58 @@ export const NotificationSettings = () => {
 
   const isEnabled = permissionStatus === 'granted' && pushToken !== null;
 
-  const handlePreferenceChange = async (key: keyof NotificationPreferences, value: boolean) => {
-    try {
-      setSavingKey(key);
-      // Update local preferences (automatically persisted by Zustand)
-      setPreference(key, value);
+  const handlePreferenceChange = useCallback(
+    async (key: keyof NotificationPreferences, value: boolean) => {
+      try {
+        setSavingKey(key);
+        // Update local preferences (automatically persisted by Zustand)
+        setPreference(key, value);
 
-      // TODO: Sync with backend
-      // try {
-      //   await api.updateNotificationPreferences({ [key]: value });
-      // } catch (error) {
-      //   console.error('Failed to sync notification preferences:', error);
-      //   // Preferences are still saved locally even if sync fails
-      // }
-    } finally {
-      setSavingKey(null);
-    }
-  };
+        // TODO: Sync with backend
+        // try {
+        //   await api.updateNotificationPreferences({ [key]: value });
+        // } catch (error) {
+        //   console.error('Failed to sync notification preferences:', error);
+        //   // Preferences are still saved locally even if sync fails
+        // }
+      } finally {
+        setSavingKey(null);
+      }
+    },
+    [setPreference]
+  );
 
-  const handleToggleAdvancedNotifications = () => {
+  const handleToggleAdvancedNotifications = useCallback(() => {
     configureNext();
     setShowAdvancedNotifications(prev => !prev);
-  };
+  }, []);
+
+  // Stable callback refs for each notification preference — prevents
+  // breaking React.memo on SettingRow when NotificationSettings re-renders.
+  const handleCourseUpdatesChange = useCallback(
+    (value: boolean) => handlePreferenceChange('courseUpdates', value),
+    [handlePreferenceChange]
+  );
+
+  const handleMessagesChange = useCallback(
+    (value: boolean) => handlePreferenceChange('messages', value),
+    [handlePreferenceChange]
+  );
+
+  const handleLearningRemindersChange = useCallback(
+    (value: boolean) => handlePreferenceChange('learningReminders', value),
+    [handlePreferenceChange]
+  );
+
+  const handleAchievementUnlocksChange = useCallback(
+    (value: boolean) => handlePreferenceChange('achievementUnlocks', value),
+    [handlePreferenceChange]
+  );
+
+  const handleCommunityActivityChange = useCallback(
+    (value: boolean) => handlePreferenceChange('communityActivity', value),
+    [handlePreferenceChange]
+  );
 
   return (
     <ScrollView className="flex-1 bg-gray-50 dark:bg-gray-900" removeClippedSubviews={true}>
@@ -127,7 +157,7 @@ export const NotificationSettings = () => {
             title="Course Updates"
             description="New lessons, content updates, and announcements"
             value={preferences.courseUpdates}
-            onValueChange={value => handlePreferenceChange('courseUpdates', value)}
+            onValueChange={handleCourseUpdatesChange}
             disabled={!isEnabled}
           />
           <View className="mx-4 h-px bg-gray-200 dark:bg-gray-700" />
@@ -137,7 +167,7 @@ export const NotificationSettings = () => {
             title="Messages"
             description="Direct messages and chat notifications"
             value={preferences.messages}
-            onValueChange={value => handlePreferenceChange('messages', value)}
+            onValueChange={handleMessagesChange}
             disabled={!isEnabled}
           />
         </View>
@@ -179,7 +209,7 @@ export const NotificationSettings = () => {
               title="Learning Reminders"
               description="Daily reminders to keep your streak"
               value={preferences.learningReminders}
-              onValueChange={value => handlePreferenceChange('learningReminders', value)}
+              onValueChange={handleLearningRemindersChange}
               disabled={!isEnabled}
             />
             <View className="mx-4 h-px bg-gray-200 dark:bg-gray-700" />
@@ -189,7 +219,7 @@ export const NotificationSettings = () => {
               title="Achievement Unlocks"
               description="Celebrate when you unlock achievements"
               value={preferences.achievementUnlocks}
-              onValueChange={value => handlePreferenceChange('achievementUnlocks', value)}
+              onValueChange={handleAchievementUnlocksChange}
               disabled={!isEnabled}
             />
             <View className="mx-4 h-px bg-gray-200 dark:bg-gray-700" />
@@ -199,7 +229,7 @@ export const NotificationSettings = () => {
               title="Community Activity"
               description="Posts, comments, and community updates"
               value={preferences.communityActivity}
-              onValueChange={value => handlePreferenceChange('communityActivity', value)}
+              onValueChange={handleCommunityActivityChange}
               disabled={!isEnabled}
             />
           </View>


### PR DESCRIPTION
# Fix: SettingRow onPress/right/icon props recreated on every parent render — breaks React.memo optimization

**Closes #626**

## Problem

`SettingRow` (in `MobileSettings.tsx` and `NotificationSettings.tsx`) is wrapped with `React.memo`, but every parent re-render (theme toggle, store state change) created **new function/JSX references** for all props:

1. **`icon` prop** — Inline JSX (`<Eye size={18} color="#6366f1" />`) created a new object every render → defeats `React.memo`
2. **`right` prop** — Inline `SettingsPicker` / `NativeToggle` JSX also created new references
3. **`onPress` prop** — Several callbacks from parent props (`onChangePassword`, `onLinkedAccounts`) were not wrapped in `useCallback`
4. **`onValueChange`** — Inline arrow functions in `NotificationSettings` broke memo on `SettingRow`

This caused every `SettingRow` in the settings list to re-render on **any** unrelated store change (theme, user, network), wasting CPU cycles.

## Changes

### `src/components/mobile/MobileSettings.tsx`

| Change | Detail |
|---|---|
| **Static icon constants** | Extracted 18 static icon JSX elements to module-level constants (`ICON_EYE`, `ICON_LOCK`, etc.) — created once, never change |
| **`useMemo` for `right` elements** | Memoized all `SettingsPicker` / `NativeToggle` instances with correct dependency arrays (`profileVisibilityRight`, `twoFactorRight`, etc.) |
| **`handleChangePassword`** | New `useCallback` wrapping parent `onChangePassword` prop |
| **`handleLinkedAccounts`** | New `useCallback` wrapping parent `onLinkedAccounts` prop |

### `app/settings.tsx`

| Change | Detail |
|---|---|
| **`handleSignOut`** | Wrapped with `useCallback` with `[logout, router]` deps — stabilizes the `onSignOut` prop passed to `MobileSettings` |

### `src/components/mobile/NotificationSettings.tsx`

| Change | Detail |
|---|---|
| **`handlePreferenceChange`** | Wrapped with `useCallback` with `[setPreference]` dep |
| **`handleToggleAdvancedNotifications`** | Wrapped with `useCallback` with `[]` dep |
| **5 stable `onValueChange` handlers** | `handleCourseUpdatesChange`, `handleMessagesChange`, `handleLearningRemindersChange`, `handleAchievementUnlocksChange`, `handleCommunityActivityChange` — each wrapped in `useCallback` delegating to `handlePreferenceChange` |

### Verification

- ✅ `SettingRow` has `React.memo` in both `MobileSettings.tsx` and `NotificationSettings.tsx`
- ✅ All `useCallback` / `useMemo` dependency arrays are correct (no missing deps)
- ✅ No TypeScript errors in changed files
- ✅ Profiler should confirm 0 re-renders for settings rows on unrelated store changes (e.g., theme toggle)

## Testing

1. **TypeScript**: `npx tsc --noEmit` — only pre-existing errors in unrelated files
2. **React Profiler**: Navigate to Settings, toggle theme — `SettingRow` instances should not re-render

## Impact

- **Performance**: Eliminates O(n) unnecessary re-renders for every `SettingRow` on each parent update
- **Files changed**: 3
- **Net change**: +196 / −93 lines
