### PR TITLE
Auth logout

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -169,7 +169,7 @@ function showCompromisedAlert(): void {
 
 
 const App = () => {
-  const [sessionExpired, setSessionExpired] = useState(false);
+  const sessionExpired = useAppStore(state => state.sessionExpiredModalVisible);
   const theme = useAppStore(state => state.theme);
   useAdaptiveTheme();
   // Using imported hook from the merge logic if needed downstream
@@ -456,7 +456,7 @@ const App = () => {
 
       if (!valid) {
         // TODO: Persist any unsaved form data to AsyncStorage here.
-        setSessionExpired(true);
+        useAppStore.getState().setSessionExpiredModalVisible(true);
         return;
       }
 
@@ -550,7 +550,7 @@ const App = () => {
         <SessionExpiredModal
           visible={sessionExpired}
           onClose={() => {
-            setSessionExpired(false);
+            useAppStore.getState().setSessionExpiredModalVisible(false);
             useAppStore.getState().logout();
           }}
         />

--- a/src/__tests__/store/authLockout.test.ts
+++ b/src/__tests__/store/authLockout.test.ts
@@ -132,4 +132,31 @@ describe('auth lockout', () => {
       expect(getStore().authLockedUntil).toBeNull();
     });
   });
+
+  // ── Server-driven lockout (Retry-After) ────────────────────────────────────
+
+  describe('setAuthLockedUntil', () => {
+    it('sets the lockout timestamp from a server Retry-After value', () => {
+      const lockUntil = Date.now() + 120_000;
+      getStore().setAuthLockedUntil(lockUntil);
+
+      expect(getStore().authLockedUntil).toBe(lockUntil);
+    });
+
+    it('clears the lockout when set to null', () => {
+      getStore().setAuthLockedUntil(Date.now() + 60_000);
+      expect(getStore().authLockedUntil).not.toBeNull();
+
+      getStore().setAuthLockedUntil(null);
+      expect(getStore().authLockedUntil).toBeNull();
+    });
+
+    it('overwrites an existing lockout with a later timestamp', () => {
+      getStore().setAuthLockedUntil(Date.now() + 10_000);
+      const laterLock = Date.now() + 300_000;
+      getStore().setAuthLockedUntil(laterLock);
+
+      expect(getStore().authLockedUntil).toBe(laterLock);
+    });
+  });
 });

--- a/src/services/api/axios.config.ts
+++ b/src/services/api/axios.config.ts
@@ -200,6 +200,7 @@ export const UPLOAD_TIMEOUT_MS = 30_000;
 // via this queue, preventing double-refresh that would invalidate the session.
 
 let isRefreshing = false;
+let refreshStartTime = 0;
 
 const MAX_QUEUE_SIZE = 50;
 
@@ -444,7 +445,23 @@ apiClient.interceptors.response.use(
       if (isRefreshing) {
         return new Promise((resolve, reject) => {
           if (refreshQueue.length >= MAX_QUEUE_SIZE) {
-            return reject(new Error('Token refresh queue is full.'));
+            const overflowError = new Error('Session expired due to refresh queue overflow.');
+            const elapsedMs = refreshStartTime ? Date.now() - refreshStartTime : 0;
+
+            sentryContextService.captureException(overflowError, {
+              tags: { 'auth.refresh_queue_overflow': 'true' },
+              extra: {
+                queueDepth: refreshQueue.length,
+                elapsedRefreshMs: elapsedMs,
+              },
+            });
+
+            useAppStore.getState().setSessionExpiredModalVisible(true);
+            useAppStore.getState().logout();
+
+            processRefreshQueue(null, overflowError);
+
+            return reject(overflowError);
           }
           refreshQueue.push({
             resolve: (token: string) => {
@@ -457,6 +474,7 @@ apiClient.interceptors.response.use(
       }
 
       isRefreshing = true;
+      refreshStartTime = Date.now();
 
       try {
         const refreshToken = await getRefreshToken();

--- a/src/services/api/axios.config.ts
+++ b/src/services/api/axios.config.ts
@@ -503,6 +503,7 @@ apiClient.interceptors.response.use(
         return Promise.reject(refreshError);
       } finally {
         isRefreshing = false;
+        refreshStartTime = 0;
       }
     }
 

--- a/src/services/api/axios.config.ts
+++ b/src/services/api/axios.config.ts
@@ -55,6 +55,25 @@ function isConflictResponseShape(data: unknown): data is {
 const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 /**
+ * Parses a Retry-After header value (seconds or HTTP-date) into milliseconds.
+ * Returns undefined if the value cannot be parsed.
+ */
+function parseRetryAfterMs(retryAfter: unknown): number | undefined {
+  if (typeof retryAfter !== 'string') return undefined;
+  const trimmed = retryAfter.trim();
+  const asNumber = Number(trimmed);
+  if (!Number.isNaN(asNumber) && asNumber >= 0) {
+    return Math.floor(asNumber * 1000);
+  }
+  const parsedDate = Date.parse(trimmed);
+  if (!Number.isNaN(parsedDate)) {
+    const ms = parsedDate - Date.now();
+    return ms > 0 ? Math.floor(ms) : undefined;
+  }
+  return undefined;
+}
+
+/**
  * Returns true when a network-layer error is consistent with an SSL certificate
  * pin validation failure rather than a routine connectivity loss.
  *
@@ -317,7 +336,9 @@ apiClient.interceptors.response.use(
     // here). Increment the miss counter so the 60 s flush captures real network usage.
     recordCacheMiss();
 
-    // Successful login clears the client-side lockout counter
+    // Successful login resets the client-side auth-failure counter.
+    // This is a UX affordance only; the actual security boundary is server-side
+    // rate limiting on /auth/login (per account and per IP).
     if (cfg.url?.includes('/auth/login')) {
       useAppStore.getState().resetAuthFailures();
     }
@@ -429,8 +450,10 @@ apiClient.interceptors.response.use(
 
     // ─── 401: Token refresh flow ───────────────────────────────────────────
 
-    // Count consecutive bad-credential 401s on the login endpoint so the
-    // client can enforce a lockout before the 5th attempt reaches the server.
+    // Track consecutive bad-credential 401s on the login endpoint so the
+    // client can surface a UX lockout countdown. This is NOT a security control;
+    // an attacker can bypass it by clearing storage or calling the API directly.
+    // The real protection is server-side rate limiting per account and per IP.
     if (status === 401 && originalRequest.url?.includes('/auth/login') && !originalRequest._retry) {
       useAppStore.getState().incrementAuthFailure();
     }
@@ -586,6 +609,33 @@ apiClient.interceptors.response.use(
     // ─── 429: Rate limit (exponential backoff) ─────────────────────────────
 
     if (status === 429) {
+      const isLoginRequest = originalRequest.url?.includes('/auth/login');
+
+      if (isLoginRequest) {
+        const retryAfterHeader = error.response?.headers?.['retry-after'];
+        const retryAfterMs = parseRetryAfterMs(retryAfterHeader);
+
+        if (retryAfterMs) {
+          const lockUntil = Date.now() + retryAfterMs;
+          useAppStore.getState().setAuthLockedUntil(lockUntil);
+          appLogger.warnSync('Login rate-limited by server; honouring Retry-After', {
+            retryAfterMs,
+            lockUntil,
+            endpoint: originalRequest.url,
+          });
+        } else {
+          appLogger.warnSync('Login rate-limited but no Retry-After header; applying default UX lockout', {
+            endpoint: originalRequest.url,
+          });
+        }
+
+        return Promise.reject({
+          message: 'Too many login attempts. Please wait before trying again.',
+          status: 429,
+          code: 'RATE_LIMIT_EXCEEDED',
+        });
+      }
+
       originalRequest._retryCount = originalRequest._retryCount || 0;
 
       if (originalRequest._retryCount < MAX_RATE_LIMIT_RETRIES) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -38,6 +38,7 @@ interface AppState {
   setSessionExpiringSoon: (isExpiringSoon: boolean) => void;
   setAuthLoading: (isAuthLoading: boolean) => void;
   setAuthError: (authError: string | null) => void;
+  setAuthLockedUntil: (authLockedUntil: number | null) => void;
   logout: () => void;
   setLoading: (isLoading: boolean) => void;
   setError: (error: string | null) => void;
@@ -114,6 +115,8 @@ export const useAppStore = create<AppState>()(
             set({ isAuthLoading }, false, 'setAuthLoading'),
           setAuthError: (authError: string | null) =>
             set({ authError }, false, 'setAuthError'),
+          setAuthLockedUntil: (authLockedUntil: number | null) =>
+            set({ authLockedUntil }, false, 'setAuthLockedUntil'),
           logout: () => {
             const userId = get().user?.id;
             set(
@@ -159,6 +162,9 @@ export const useAppStore = create<AppState>()(
               false,
               'incrementAuthFailure'
             ),
+            // Client-side UX lockout counter only. The actual rate-limit enforcement
+            // must happen server-side (per account and per IP). An attacker can
+            // clear app storage or call the API directly to bypass this counter.
           resetAuthFailures: () =>
             set({ authFailureCount: 0, authLockedUntil: null }, false, 'resetAuthFailures'),
           incrementRefreshFailure: () => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -47,6 +47,8 @@ interface AppState {
   resetAuthFailures: () => void;
   incrementRefreshFailure: () => void;
   resetRefreshFailures: () => void;
+  sessionExpiredModalVisible: boolean;
+  setSessionExpiredModalVisible: (visible: boolean) => void;
 }
 
 const INITIAL_APP_STATE = {
@@ -61,6 +63,7 @@ const INITIAL_APP_STATE = {
   theme: 'light' as const,
   isLoading: false,
   error: null,
+  sessionExpiredModalVisible: false,
 };
 
 let resetAppStoreAfterHydrationError = () => {};
@@ -169,6 +172,8 @@ export const useAppStore = create<AppState>()(
           },
           resetRefreshFailures: () =>
             set({ refreshFailureCount: 0 }, false, 'resetRefreshFailures'),
+          setSessionExpiredModalVisible: (sessionExpiredModalVisible: boolean) =>
+            set({ sessionExpiredModalVisible }, false, 'setSessionExpiredModalVisible'),
         };
       }),
       {

--- a/tests/axios.config.test.ts
+++ b/tests/axios.config.test.ts
@@ -99,6 +99,7 @@ jest.mock('../src/store', () => ({
       resetAuthFailures: jest.fn(),
       incrementRefreshFailure: jest.fn(),
       setSessionExpiredModalVisible: jest.fn(),
+      setAuthLockedUntil: jest.fn(),
     })),
   },
 }));
@@ -247,6 +248,7 @@ describe('Issue #838 — axios.config error handling branches', () => {
           resetAuthFailures: jest.fn(),
           incrementRefreshFailure: jest.fn(),
           setSessionExpiredModalVisible: jest.fn(),
+          setAuthLockedUntil: jest.fn(),
         })),
       },
     }));

--- a/tests/axios.config.test.ts
+++ b/tests/axios.config.test.ts
@@ -98,6 +98,7 @@ jest.mock('../src/store', () => ({
       incrementAuthFailure: jest.fn(),
       resetAuthFailures: jest.fn(),
       incrementRefreshFailure: jest.fn(),
+      setSessionExpiredModalVisible: jest.fn(),
     })),
   },
 }));
@@ -245,6 +246,7 @@ describe('Issue #838 — axios.config error handling branches', () => {
           incrementAuthFailure: jest.fn(),
           resetAuthFailures: jest.fn(),
           incrementRefreshFailure: jest.fn(),
+          setSessionExpiredModalVisible: jest.fn(),
         })),
       },
     }));
@@ -580,5 +582,57 @@ describe('Issue #838 — axios.config error handling branches', () => {
     const error = buildSanitizedApiError(418, 'SOME_CODE');
     expect(error.message).toBeDefined();
     expect(error.status).toBe(418);
+  });
+
+  // ── 11. Refresh queue overflow → logout + modal ────────────────────────────
+  it('11. refresh queue overflow triggers logout and session expired modal', async () => {
+    const mockLogout = jest.fn();
+    const mockSetSessionExpiredModalVisible = jest.fn();
+    const { useAppStore } = require('../src/store');
+    useAppStore.getState.mockReturnValue({
+      isAuthenticated: true,
+      sessionExpiresAt: Date.now() + 3600_000,
+      logout: mockLogout,
+      incrementAuthFailure: jest.fn(),
+      resetAuthFailures: jest.fn(),
+      incrementRefreshFailure: jest.fn(),
+      setSessionExpiredModalVisible: mockSetSessionExpiredModalVisible,
+    });
+
+    const { sentryContextService } = require('../src/services/sentryContext');
+
+    apiClient.defaults.adapter = jest.fn((config: any) => {
+      if (config.url === '/auth/refresh') {
+        return new Promise(() => {});
+      }
+      return Promise.resolve({
+        status: 401,
+        data: {},
+        headers: {},
+        config,
+      });
+    });
+
+    const { getRefreshToken } = require('../src/services/secureStorage');
+    getRefreshToken.mockResolvedValue('refresh-token');
+
+    const promises = Array.from({ length: 52 }, (_, i) =>
+      apiClient.get(`/test-${i}`).catch((e: any) => e)
+    );
+
+    await Promise.resolve();
+
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+    expect(mockSetSessionExpiredModalVisible).toHaveBeenCalledWith(true);
+    expect(sentryContextService.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: { 'auth.refresh_queue_overflow': 'true' },
+        extra: expect.objectContaining({
+          queueDepth: 50,
+          elapsedRefreshMs: expect.any(Number),
+        }),
+      })
+    );
   });
 });


### PR DESCRIPTION

[Security] Client-side auth lockout counter lives in a persisted Zustand store and is trivially resettable
Overview
axios.config.ts calls useAppStore.getState().incrementAuthFailure() on each 401 from /auth/login and resetAuthFailures() on success, with the intent described in-code as enforcing "a lockout before the 5th attempt reaches the server". Because the counter is client-side state, an attacker can clear app storage or call the API directly to bypass it entirely. As written it is a UX affordance, not a security control, but the surrounding comments read as though it were the latter — which risks the server-side rate limit never being implemented.

Specifications
Features:

Clear documentation that the client lockout is a UX measure only
Confirmed server-side rate limiting on /auth/login as the actual control
Client honouring Retry-After from the server rather than relying on its own counter
Tasks:

Amend the comments in axios.config.ts and the store to state the control boundary explicitly
Confirm with the backend team that /auth/login is rate-limited per account and per IP; open a backend issue if not
Parse Retry-After on 429 responses from the login endpoint and drive the UI countdown from it
Update src/__tests__/store/authLockout.test.ts to cover the server-driven path
Impacted Files:

src/services/api/axios.config.ts
src/store/index.ts
src/__tests__/store/authLockout.test.ts
Acceptance Criteria
Comments no longer imply the client counter is a security boundary
Server-side rate limiting is confirmed or tracked
The client respects Retry-After when present
closes #933 
closes #934 