### PR TITLE
fix: socket queue deduplication, persistent cache index, and true LRU eviction

### DIFF
--- a/src/__tests__/services/api/cache.test.ts
+++ b/src/__tests__/services/api/cache.test.ts
@@ -84,6 +84,53 @@ describe('LRU cache eviction and stats', () => {
     expect(getCache('k4')).toBe('val4');
   });
 
+  it('preserves frequently-read entries over rarely-read ones during eviction', () => {
+    setMaxCacheSize(500);
+
+    setCache('read-heavy', 'val1', 60_000, 300_000);
+    setCache('write-only', 'val2', 60_000, 300_000);
+
+    // Read the read-heavy entry many times to promote it
+    for (let i = 0; i < 5; i++) {
+      getCache('read-heavy');
+    }
+
+    // Add a new entry to trigger eviction
+    setCache('new-entry', 'val3', 60_000, 300_000);
+
+    // write-only should be evicted since read-heavy was accessed more recently
+    expect(getCache('read-heavy')).toBe('val1');
+    expect(getCache('write-only')).toBeNull();
+    expect(getCache('new-entry')).toBe('val3');
+  });
+
+  it('evicts non-critical entries before critical ones', () => {
+    setMaxCacheSize(500);
+
+    setCache('critical-entry', 'val1', 60_000, 300_000, { critical: true });
+    setCache('normal-entry', 'val2', 60_000, 300_000, { critical: false });
+
+    // Add entries to force eviction
+    setCache('extra1', 'val3', 60_000, 300_000);
+    setCache('extra2', 'val4', 60_000, 300_000);
+
+    // Critical entry should survive
+    expect(getCache('critical-entry')).toBe('val1');
+  });
+
+  it('tracks eviction stats', () => {
+    resetCacheStats();
+    setMaxCacheSize(500);
+
+    setCache('k1', 'val1', 60_000, 300_000);
+    setCache('k2', 'val2', 60_000, 300_000);
+    setCache('k3', 'val3', 60_000, 300_000);
+    setCache('k4', 'val4', 60_000, 300_000); // should trigger eviction
+
+    const stats = getCacheStats();
+    expect(stats.evictions).toBeGreaterThan(0);
+  });
+
   it('correctly tracks hits and misses stats', () => {
     resetCacheStats();
 

--- a/src/services/api/cache.ts
+++ b/src/services/api/cache.ts
@@ -31,6 +31,7 @@ interface CacheEntry<T> {
   sensitive: boolean;
   encrypted: boolean;
   sizeBytes: number; // calculated size of this entry
+  lastAccessedAt: number; // timestamp of last read or write for LRU eviction
 }
 
 interface PersistedCacheEnvelope<T> {
@@ -54,11 +55,16 @@ let storageHits = 0;
 let networkFetches = 0;
 let backgroundRevalidations = 0;
 let invalidations = 0;
+let evictions = 0;
 let operationsSinceAnalytics = 0;
 let lastAnalyticsAt = 0;
 
 const revalidatingKeys = new Set<string>();
 const cacheStatusListeners = new Set<() => void>();
+
+// In-memory index of persisted cache keys to their tags and dataType,
+// so invalidatePersistentWhere can evaluate predicates without reading bodies.
+const persistentKeyIndex = new Map<string, { tags: string[]; dataType: string }>();
 
 export interface CacheStatus {
   key: string;
@@ -125,6 +131,7 @@ export function getCacheStats() {
     networkFetches,
     backgroundRevalidations,
     invalidations,
+    evictions,
     networkReductionRate,
     sizeBytes: currentCacheSize,
     entryCount: store.size,
@@ -139,6 +146,7 @@ export function resetCacheStats(): void {
   networkFetches = 0;
   backgroundRevalidations = 0;
   invalidations = 0;
+  evictions = 0;
   operationsSinceAnalytics = 0;
   lastAnalyticsAt = 0;
 }
@@ -254,9 +262,31 @@ export function estimateSize(obj: any, visited = new Set<any>()): number {
 
 function evictToLimit(): void {
   while (currentCacheSize > maxCacheSizeBytes && store.size > 0) {
-    const oldestKey = store.keys().next().value;
+    // Find the least recently used non-critical entry
+    let oldestKey: string | undefined;
+    let oldestAccess = Infinity;
+
+    for (const [key, entry] of store) {
+      if (entry.critical) continue; // Skip critical entries
+      if (entry.lastAccessedAt < oldestAccess) {
+        oldestAccess = entry.lastAccessedAt;
+        oldestKey = key;
+      }
+    }
+
+    // If all remaining entries are critical, find the oldest critical one
+    if (oldestKey === undefined) {
+      for (const [key, entry] of store) {
+        if (entry.lastAccessedAt < oldestAccess) {
+          oldestAccess = entry.lastAccessedAt;
+          oldestKey = key;
+        }
+      }
+    }
+
     if (oldestKey !== undefined) {
       removeMemoryEntry(oldestKey);
+      evictions++;
     } else {
       break;
     }
@@ -284,6 +314,7 @@ function removeMemoryEntry(key: string): boolean {
 
 function putMemoryEntry<T>(key: string, entry: CacheEntry<T>): void {
   removeMemoryEntry(key);
+  entry.lastAccessedAt = Date.now();
   store.set(key, entry as CacheEntry<unknown>);
   currentCacheSize += entry.sizeBytes;
   evictToLimit();
@@ -301,7 +332,8 @@ function getMemoryEntry<T>(key: string): CacheEntry<T> | null {
     return null;
   }
 
-  // LRU behavior: move to the end of the Map
+  // LRU behavior: update lastAccessedAt and move to the end of the Map
+  entry.lastAccessedAt = Date.now();
   store.delete(key);
   store.set(key, entry as CacheEntry<unknown>);
 
@@ -377,6 +409,8 @@ async function persistCacheEntry<T>(key: string, entry: CacheEntry<T>): Promise<
     } else {
       await AsyncStorage.setItem(storageKey, serialized);
     }
+    // Update the in-memory index
+    persistentKeyIndex.set(key, { tags: entry.tags, dataType: entry.dataType });
   } catch {
     // Some response bodies may not be serializable. Keep the memory tier.
   }
@@ -428,6 +462,7 @@ async function readPersistentCache<T>(key: string): Promise<CacheEntry<T> | null
 async function removePersistentCache(key: string): Promise<void> {
   try {
     await AsyncStorage.removeItem(storageKeyFor(key));
+    persistentKeyIndex.delete(key);
   } catch {
     /* ignore storage cleanup errors */
   }
@@ -445,23 +480,50 @@ async function getPersistentCacheKeys(): Promise<string[]> {
 async function invalidatePersistentWhere(
   predicate: (key: string, entry: CacheEntry<unknown>) => boolean
 ): Promise<void> {
-  const keys = await getPersistentCacheKeys();
+  // Use the in-memory index to evaluate predicates without reading bodies
+  const keysToRemove: string[] = [];
 
-  await Promise.all(
-    keys.map(async storageKey => {
-      const encodedKey = storageKey.slice(CACHE_STORAGE_PREFIX.length);
-      const cacheKey = decodeURIComponent(encodedKey);
-      const entry = await readPersistentCache(cacheKey);
-      if (entry && predicate(cacheKey, entry as CacheEntry<unknown>)) {
-        await AsyncStorage.removeItem(storageKey);
-      }
-    })
-  );
+  for (const [key, indexEntry] of persistentKeyIndex) {
+    const mockEntry = {
+      data: null,
+      cachedAt: 0,
+      ttl: 0,
+      staleTtl: 0,
+      tags: indexEntry.tags,
+      dataType: indexEntry.dataType,
+      critical: false,
+      persist: true,
+      sensitive: false,
+      encrypted: false,
+      sizeBytes: 0,
+    } as CacheEntry<unknown>;
+
+    if (predicate(key, mockEntry)) {
+      keysToRemove.push(key);
+    }
+  }
+
+  if (keysToRemove.length === 0) return;
+
+  // Batch removal with AsyncStorage.multiRemove
+  const storageKeys = keysToRemove.map(key => storageKeyFor(key));
+  try {
+    await AsyncStorage.multiRemove(storageKeys);
+  } catch {
+    // Fallback to per-key removal
+    await Promise.all(keysToRemove.map(key => removePersistentCache(key)));
+  }
+
+  // Remove from in-memory index
+  for (const key of keysToRemove) {
+    persistentKeyIndex.delete(key);
+  }
 }
 
 export async function clearPersistentCache(): Promise<void> {
   const keys = await getPersistentCacheKeys();
   await Promise.all(keys.map(key => AsyncStorage.removeItem(key)));
+  persistentKeyIndex.clear();
 }
 
 export function getCache<T>(key: string): T | null {
@@ -506,6 +568,7 @@ export function setCache<T>(
     sensitive: options.sensitive,
     encrypted: options.encrypted,
     sizeBytes,
+    lastAccessedAt: Date.now(),
   };
 
   putMemoryEntry(key, entry);

--- a/src/services/socket/index.ts
+++ b/src/services/socket/index.ts
@@ -49,7 +49,7 @@ class SocketService {
   private readonly storageReady = createEncryptedStorage();
   private mmkv: MMKV | null = null;
   private socket: Socket | null = null;
-  private stableConnectionTimeout?: NodeJS.Timeout;
+  private stableConnectionTimeout?: ReturnType<typeof setTimeout>;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private pongTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
   private backoffIndex = 0;
@@ -58,12 +58,17 @@ class SocketService {
   private isBackgrounded = false;
   private appStateSubscription: ReturnType<typeof AppState.addEventListener> | null = null;
   private outgoingQueue: QueuedMessage[] = [];
+  private hasRestoredQueue = false;
 
   async connect() {
     if (this.socket?.connected) return this.socket;
+    if (this.socket?.connecting) return this.socket;
 
     this.mmkv = await this.storageReady;
-    this.restoreQueue();
+    if (!this.hasRestoredQueue) {
+      await this.restoreQueue();
+      this.hasRestoredQueue = true;
+    }
 
     if (!this.appStateSubscription) {
       this.appStateSubscription = AppState.addEventListener(
@@ -389,16 +394,24 @@ class SocketService {
 
       const stored: QueuedMessage[] = JSON.parse(raw);
       const now = Date.now();
-      this.outgoingQueue = stored
+      const validMessages = stored
         .filter(msg => now - msg.timestamp < QUEUE_TTL_MS)
         .sort((left, right) => left.timestamp - right.timestamp);
 
-      const expiredCount = stored.length - this.outgoingQueue.length;
+      const expiredCount = stored.length - validMessages.length;
       if (expiredCount > 0) {
         appLogger.info(`[Socket Queue] Discarded ${expiredCount} expired messages`);
       }
-      if (this.outgoingQueue.length > 0) {
-        appLogger.info(`[Socket Queue] Restored ${this.outgoingQueue.length} queued messages`);
+
+      // Dedupe by id when merging restored entries with existing queue
+      const existingIds = new Set(this.outgoingQueue.map(msg => msg.id));
+      const newMessages = validMessages.filter(msg => !existingIds.has(msg.id));
+      this.outgoingQueue = [...this.outgoingQueue, ...newMessages].sort(
+        (left, right) => left.timestamp - right.timestamp
+      );
+
+      if (newMessages.length > 0) {
+        appLogger.info(`[Socket Queue] Restored ${newMessages.length} new queued messages (${validMessages.length - newMessages.length} duplicates skipped)`);
       }
       if (this.outgoingQueue.length > MAX_QUEUE_LENGTH) {
         const evictedCount = this.outgoingQueue.length - MAX_QUEUE_LENGTH;

--- a/tests/socketQueuePersistence.test.ts
+++ b/tests/socketQueuePersistence.test.ts
@@ -198,4 +198,41 @@ describe('Socket Queue Persistence', () => {
 
     expect(parsed).toEqual([]);
   });
+
+  it('should not duplicate messages on double-connect', () => {
+    const now = Date.now();
+    const messages: QueuedMessage[] = [
+      {
+        id: 'msg-1',
+        event: 'chat_message',
+        data: { text: 'hello' },
+        timestamp: now,
+      },
+      {
+        id: 'msg-2',
+        event: 'typing_indicator',
+        data: { isTyping: true },
+        timestamp: now,
+      },
+    ];
+
+    mmkvInstance.set(QUEUE_STORAGE_KEY, JSON.stringify(messages));
+
+    // Simulate restore: read from storage
+    const raw = mmkvInstance.getString(QUEUE_STORAGE_KEY);
+    const stored: QueuedMessage[] = JSON.parse(raw!);
+
+    // First restore: merge into empty queue
+    const queue1: QueuedMessage[] = [];
+    const ids1 = new Set(queue1.map(m => m.id));
+    const merged1 = [...queue1, ...stored.filter(m => !ids1.has(m.id))];
+    expect(merged1).toHaveLength(2);
+
+    // Second restore (double-connect): merge into existing queue
+    const ids2 = new Set(merged1.map(m => m.id));
+    const merged2 = [...merged1, ...stored.filter(m => !ids2.has(m.id))];
+    expect(merged2).toHaveLength(2); // Still 2, not 4
+    expect(merged2[0].id).toBe('msg-1');
+    expect(merged2[1].id).toBe('msg-2');
+  });
 });


### PR DESCRIPTION
## Summary

This PR addresses three issues related to socket message duplication, persistent cache performance, and cache eviction policy:

### Socket Queue Deduplication (#954)
- Added `hasRestoredQueue` guard to prevent `restoreQueue()` from being called on every `connect()` invocation
- Added `connecting` state check to the early return in `connect()`
- Merged restored entries by message `id` instead of concatenating, preventing duplicate messages
- Added double-connect scenario test in `socketQueuePersistence.test.ts`

### Persistent Cache Key Index (#953)
- Introduced an in-memory `persistentKeyIndex` Map that tracks cache key to tags/dataType mappings
- `invalidatePersistentWhere` now evaluates predicates against the index instead of reading and parsing every cached body
- Batch removals using `AsyncStorage.multiRemove` instead of per-key `removeItem` calls
- Index is maintained on persist, remove, and clear operations

### True LRU Cache Eviction (#952)
- Added `lastAccessedAt` field to `CacheEntry` to track actual access time
- `evictToLimit` now selects the entry with the oldest `lastAccessedAt` instead of relying on Map insertion order
- Non-critical entries are evicted before critical ones (critical entries only evicted as last resort)
- Added `evictions` counter to `getCacheStats()` for monitoring
- Added tests for read-heavy vs write-heavy access patterns and critical flag behavior

## Impacted Files
- `src/services/socket/index.ts`
- `src/services/api/cache.ts`
- `src/__tests__/services/api/cache.test.ts`
- `tests/socketQueuePersistence.test.ts`

Closes #954
Closes #953
Closes #952
