### PR TITLE
fix: resolve module-level timer, type errors, and IAP v15 migration

### DIFF
--- a/docs/payments/receipt-validation-flow.md
+++ b/docs/payments/receipt-validation-flow.md
@@ -21,7 +21,7 @@ User taps "Subscribe"
 IAP.requestSubscription()   ←── opens native payment sheet
        │
        ▼ (purchase approved by platform)
-purchaseUpdatedListener fires with { transactionReceipt }
+purchaseUpdatedListener fires with { transactionId }
        │
        ├─ receiptValidationPending === true? → skip (duplicate guard)
        │

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -240,7 +240,6 @@ jest.mock('react-native-iap', () => ({
   initConnection: jest.fn(() => Promise.resolve(true)),
   endConnection: jest.fn(),
   getProducts: jest.fn(() => Promise.resolve([])),
-  getSubscriptions: jest.fn(() => Promise.resolve([])),
   requestPurchase: jest.fn(() => Promise.resolve({})),
   requestSubscription: jest.fn(() => Promise.resolve({})),
   finishTransaction: jest.fn(() => Promise.resolve(true)),
@@ -491,3 +490,9 @@ jest.mock('expo-clipboard', () => ({
   addClipboardListener: jest.fn(() => ({ remove: jest.fn() })),
   removeClipboardListener: jest.fn(),
 }), { virtual: true });
+
+// Clean up any open handles from axios.config.ts interval
+const { stopCacheStatsFlush } = require('./src/services/api/axios.config');
+afterAll(() => {
+  stopCacheStatsFlush();
+});

--- a/src/__tests__/services/mobilePayments.test.ts
+++ b/src/__tests__/services/mobilePayments.test.ts
@@ -49,10 +49,7 @@ function makeNetworkError(): Error {
 const makePurchase = (productId: string, receipt: string) => ({
   productId,
   transactionId: `txn_${productId}`,
-  transactionReceipt: receipt,
   transactionDate: new Date().toISOString(),
-  priceAmountMicros: 9_990_000,
-  priceCurrencyCode: 'USD',
 });
 
 // ─── restorePurchases (#615) ──────────────────────────────────────────────────
@@ -224,7 +221,7 @@ describe('purchaseUpdatedListener (via initialize)', () => {
     await mobilePaymentsService.initialize();
   });
 
-  const MOCK_IAP_PURCHASE = { transactionReceipt: MOCK_RECEIPT, productId: MOCK_PRODUCT_ID };
+  const MOCK_IAP_PURCHASE = { transactionId: MOCK_RECEIPT, productId: MOCK_PRODUCT_ID };
 
   it('sets receiptValidationPending true then false around a successful validation', async () => {
     mockApi.post.mockResolvedValueOnce({ data: { valid: true, tier: 'pro' } });
@@ -278,8 +275,8 @@ describe('purchaseUpdatedListener (via initialize)', () => {
     expect(mockIAP.finishTransaction).not.toHaveBeenCalled();
   });
 
-  it('ignores purchases without a transactionReceipt', async () => {
-    await capturedListener!({ productId: MOCK_PRODUCT_ID, transactionReceipt: undefined });
+  it('ignores purchases without a transactionId', async () => {
+    await capturedListener!({ productId: MOCK_PRODUCT_ID, transactionId: undefined });
 
     expect(mockApi.post).not.toHaveBeenCalled();
     expect(mockStoreState.setReceiptValidationPending).not.toHaveBeenCalled();

--- a/src/components/AppLifecycleManager.tsx
+++ b/src/components/AppLifecycleManager.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { AppState, AppStateStatus } from 'react-native';
 
+import { startCacheStatsFlush, stopCacheStatsFlush, flushCacheStatsNow } from '../services/api/axios.config';
 import { mobileAnalyticsService } from '@/services/mobileAnalytics';
 import { useDeviceStore } from '@/store/deviceStore';
 import { AnalyticsEvent } from '@/utils/trackingEvents';
@@ -10,12 +11,21 @@ const AppLifecycleManager = () => {
   const appStateRef = useRef<AppStateStatus>(AppState.currentState as AppStateStatus);
 
   useEffect(() => {
+    startCacheStatsFlush();
+
     const subscription = AppState.addEventListener('change', (nextState: AppStateStatus) => {
       const prev = appStateRef.current;
       appStateRef.current = nextState;
 
       const isBackground = nextState !== 'active';
       setIsInBackground(isBackground);
+
+      if (isBackground) {
+        flushCacheStatsNow();
+        stopCacheStatsFlush();
+      } else {
+        startCacheStatsFlush();
+      }
 
       // Track transitions for monitoring battery/behavior impact
       mobileAnalyticsService.trackEvent(
@@ -25,6 +35,7 @@ const AppLifecycleManager = () => {
     });
 
     return () => {
+      stopCacheStatsFlush();
       subscription.remove();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/mobile/MobileVideoPlayer.tsx
+++ b/src/components/mobile/MobileVideoPlayer.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../services/videoQuality';
 import { ErrorBoundary } from '../common/ErrorBoundary';
 import { positionStore } from '../../services/positionStore';
+import { scheduleAnimationFrame } from '../../utils/animationScheduler';
 
 const AUTO_HIDE_MS = 3000;
 const DEFAULT_ASPECT_RATIO = 16 / 9;
@@ -145,7 +146,7 @@ const MobileVideoPlayer = ({
   }, []);
 
   const { isPiPSupported, isPiPActive, enterPiP, exitPiP } = usePictureInPicture({
-    videoRef,
+    videoRef: videoRef as React.RefObject<Video>,
     isPlaying,
   });
 
@@ -411,7 +412,6 @@ const MobileVideoPlayer = ({
       }
     },
     [autoPlay, isSwitchingQuality, onEnd, onError, onPlaybackStatusUpdate, attemptRecovery]
-    [autoPlay, isSwitchingQuality, onEnd, onError, onPlaybackStatusUpdate]
   );
 
   useEffect(() => {

--- a/src/components/mobile/profile/ProfileSettings.tsx
+++ b/src/components/mobile/profile/ProfileSettings.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { Controller } from 'react-hook-form';
+import { Controller, type Control, type FieldErrors } from 'react-hook-form';
 import { ChevronDown, ChevronUp, User, Mail, MapPin, Globe } from 'lucide-react-native';
 import { MobileFormInput } from '../MobileFormInput';
 
+interface ProfileFormValues {
+  name: string;
+  email: string;
+  bio: string;
+  location: string;
+  website: string;
+}
+
 interface Props {
-  control: any;
-  formErrors: any;
+  control: Control<ProfileFormValues>;
+  formErrors: FieldErrors<ProfileFormValues>;
   showAdvancedFields: boolean;
   onToggleAdvancedFields: () => void;
   isDark?: boolean;
@@ -84,3 +92,30 @@ export const ProfileSettings = React.memo(({ control, formErrors, showAdvancedFi
 });
 
 ProfileSettings.displayName = 'ProfileSettings';
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 12,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#1e293b',
+    marginBottom: 4,
+  },
+  disclosureToggle: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 12,
+    paddingHorizontal: 4,
+  },
+  disclosureToggleText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#19c3e6',
+  },
+  disclosureContent: {
+    gap: 12,
+  },
+});

--- a/src/services/api/axios.config.ts
+++ b/src/services/api/axios.config.ts
@@ -186,8 +186,21 @@ function flushCacheStats(): void {
 /** Flush immediately (e.g. on app background). */
 export const flushCacheStatsNow = flushCacheStats;
 
-// Start the periodic flush loop once when the module loads.
-setInterval(flushCacheStats, CACHE_STATS_INTERVAL_MS);
+let _cacheStatsInterval: ReturnType<typeof setInterval> | null = null;
+
+/** Start the periodic cache-stats flush interval. Idempotent. */
+export function startCacheStatsFlush(): void {
+  if (_cacheStatsInterval !== null) return;
+  _cacheStatsInterval = setInterval(flushCacheStats, CACHE_STATS_INTERVAL_MS);
+}
+
+/** Stop the periodic cache-stats flush interval and flush remaining stats. */
+export function stopCacheStatsFlush(): void {
+  if (_cacheStatsInterval === null) return;
+  clearInterval(_cacheStatsInterval);
+  _cacheStatsInterval = null;
+  flushCacheStats();
+}
 
 // ─── Rate Limit Backoff (Issue #141) ──────────────────────────────────────
 

--- a/src/services/mobilePayments.ts
+++ b/src/services/mobilePayments.ts
@@ -178,7 +178,7 @@ class MobilePaymentsService {
       await IAP.initConnection();
 
       IAP.purchaseUpdatedListener(async purchase => {
-        const receipt = purchase.transactionReceipt;
+        const receipt = purchase.transactionId;
         if (!receipt) return;
 
         const store = useAppStore.getState();
@@ -232,7 +232,7 @@ class MobilePaymentsService {
    */
   async getProducts(productIds: string[]): Promise<SubscriptionPlan[]> {
     try {
-      const storeProducts = await IAP.getSubscriptions({ skus: productIds });
+      const storeProducts = await IAP.getProducts({ skus: productIds });
       return storeProducts.map(sp => {
         const plan = SUBSCRIPTION_PLANS.find(p => p.productId === sp.productId);
         return {
@@ -267,7 +267,7 @@ class MobilePaymentsService {
     if (!plan) throw new Error(`Unknown product: ${productId}`);
 
     try {
-      await IAP.requestSubscription({ sku: productId });
+      await IAP.requestSubscription({ skus: [productId] });
 
       // The actual purchase completion is handled by purchaseUpdatedListener.
       // For the hook, we await a Promise that resolves when the listener fires.
@@ -306,7 +306,7 @@ class MobilePaymentsService {
   async purchaseProduct(productId: string): Promise<PurchaseRecord> {
     this._throwIfDeviceCompromised();
     try {
-      await IAP.requestPurchase({ sku: productId });
+      await IAP.requestPurchase({ skus: [productId] });
 
       // ── Fallback mock for development ──
       const record: PurchaseRecord = {
@@ -342,7 +342,7 @@ class MobilePaymentsService {
       const validated: PurchaseRecord[] = [];
 
       for (const purchase of available) {
-        const receipt = purchase.transactionReceipt;
+        const receipt = purchase.transactionId;
         if (receipt) {
           const result = await this.validateReceipt(
             receipt,
@@ -354,10 +354,8 @@ class MobilePaymentsService {
               id: purchase.transactionId,
               productId: purchase.productId,
               transactionId: purchase.transactionId,
-              amount: parseFloat(
-                purchase.priceAmountMicros ? String(purchase.priceAmountMicros / 1000000) : '0'
-              ),
-              currency: purchase.priceCurrencyCode ?? 'USD',
+              amount: 0,
+              currency: 'USD',
               type: purchase.productId.includes('subscription') ? 'subscription' : 'one_time',
               status: 'restored',
               purchasedAt: purchase.transactionDate


### PR DESCRIPTION
## Summary

This PR addresses four bugs affecting build correctness and runtime behavior:

### #944 — ProfileSettings.tsx references undefined `styles` object
- Added a complete `StyleSheet.create` block defining all referenced style keys
- Typed the `control` and `formErrors` props using `react-hook-form`'s generic types

### #945 — mobilePayments.ts written against react-native-iap v15 API
- Replaced `getSubscriptions` with `getProducts` (v15 unified product fetching)
- Updated `requestSubscription` and `requestPurchase` to accept `{ skus: string[] }` instead of `{ sku }`
- Replaced `purchase.transactionReceipt` with `purchase.transactionId`
- Removed references to deprecated `priceAmountMicros` and `priceCurrencyCode`
- Updated jest.setup.js mock and receipt validation docs

### #946 — MobileVideoPlayer.tsx calls undefined `scheduleAnimationFrame`
- Restored the missing import from `src/utils/animationScheduler.ts`
- Fixed the malformed duplicate dependency array at line 413-414
- Added type assertion for the video ref to satisfy React 19 ref semantics

### #947 — Module-level setInterval never cleared
- Replaced the bare `setInterval` with exported `startCacheStatsFlush()` / `stopCacheStatsFlush()` functions
- Wired `AppLifecycleManager` to start the interval on foreground and stop on background
- Added `afterAll` teardown in `jest.setup.js` to prevent open handle leaks
- Stats are still flushed before the app suspends via `flushCacheStatsNow()`

Closes #944
Closes #945
Closes #946
Closes #947