### PR TITLE
fix: use authoritative cache stats from cache.ts for accurate hit rate reporting

### DIFF
--- a/src/services/api/axios.config.ts
+++ b/src/services/api/axios.config.ts
@@ -147,31 +147,17 @@ function invalidateSuccessfulMutationCache(config: InternalAxiosRequestConfig): 
 
 // ─── Batched cache statistics (#811) ──────────────────────────────────────────
 //
-// Computing cache hit-rate on every successful response adds JS-thread overhead
-// proportional to request frequency. Instead, we keep two integer counters and
-// flush aggregated stats to the logger on a 60-second interval, reducing
-// per-response work to a single increment.
+// Cache.ts maintains the authoritative hit/miss counters via recordHit/recordMiss.
+// This module reads those counters on a 60-second interval and logs a summary,
+// avoiding duplicate counter implementations.
 
-interface CacheStats {
-  hits: number;
-  misses: number;
-}
+import { getCacheStats } from './cache';
 
-const _cacheStats: CacheStats = { hits: 0, misses: 0 };
 const CACHE_STATS_INTERVAL_MS = 60_000;
 
-/** Call when the SWR cache serves a response without a network round-trip. */
-export function recordCacheHit(): void {
-  _cacheStats.hits++;
-}
-
-/** Call when a full network request was needed (no usable cached value). */
-export function recordCacheMiss(): void {
-  _cacheStats.misses++;
-}
-
 function flushCacheStats(): void {
-  const { hits, misses } = _cacheStats;
+  const stats = getCacheStats();
+  const { hits, misses } = stats;
   const total = hits + misses;
   if (total === 0) return;
   const hitRate = ((hits / total) * 100).toFixed(1);
@@ -179,8 +165,6 @@ function flushCacheStats(): void {
     `[CacheStats] ${hitRate}% hit rate over last 60 s (${hits}/${total} requests served from cache)`,
     { cacheHits: hits, cacheMisses: misses, hitRatePct: parseFloat(hitRate) }
   );
-  _cacheStats.hits = 0;
-  _cacheStats.misses = 0;
 }
 
 /** Flush immediately (e.g. on app background). */
@@ -331,10 +315,6 @@ apiClient.interceptors.response.use(
       statusCode: response.status,
     });
     invalidateSuccessfulMutationCache(cfg);
-    // #811: every response that reaches this interceptor was a network round-trip
-    // (SWR cache hits are returned before the request is dispatched and never arrive
-    // here). Increment the miss counter so the 60 s flush captures real network usage.
-    recordCacheMiss();
 
     // Successful login resets the client-side auth-failure counter.
     // This is a UX affordance only; the actual security boundary is server-side


### PR DESCRIPTION
## Summary

The axios response interceptor unconditionally called `recordCacheMiss()` on every successful response, while `recordCacheHit()` was exported but never called anywhere in the codebase. This meant `flushCacheStats()` always computed `hits = 0` and the 60-second log line reported `0.0% hit rate` regardless of actual cache performance.

Meanwhile, `src/services/api/cache.ts` maintains its own separate, correct counters (`cacheHits`, `memoryHits`, `storageHits`) via `recordHit()` and `recordMiss()`.

### Changes

- Removed the local `_cacheStats` counters and `recordCacheHit()` / `recordCacheMiss()` exports from `axios.config.ts`
- `flushCacheStats()` now reads directly from `getCacheStats()` in `cache.ts`, which maintains the correct hit/miss counters
- Removed the redundant `recordCacheMiss()` call from the response interceptor (cache.ts already tracks network fetches)

### Impact

- The logged hit rate now reflects real cache behaviour
- Only one cache-statistics implementation remains (in `cache.ts`)
- The 60-second summary log will show non-zero hit rates when the SWR cache serves responses

Closes #948