### PR TITLE
fix: resolve missing imports, broken hooks, and unsafe runtime globals

### DIFF
--- a/src/components/mobile/MobileSettings.tsx
+++ b/src/components/mobile/MobileSettings.tsx
@@ -19,7 +19,7 @@ import {
   Wifi,
   Zap,
 } from 'lucide-react-native';
-import React, { memo, useCallback, useRef, useState } from 'react';
+import React, { memo, useCallback, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Alert, Platform, ScrollView, TextInput, TouchableOpacity, View } from 'react-native';
 import { useRouter } from 'expo-router';
 

--- a/src/hooks/useBiometricAuth.ts
+++ b/src/hooks/useBiometricAuth.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AppState } from 'react-native';
+
+import {
+  isBiometricEnrolled,
+  authenticateWithBiometrics,
+} from '../services/biometricAuth';
+import {
+  isBiometricEnabled,
+  setBiometricEnabled,
+} from '../services/secureStorage';
+import { useDeviceStore } from '../store/deviceStore';
+
+interface UseBiometricAuthReturn {
+  isAvailable: boolean;
+  isEnabled: boolean;
+  isLoading: boolean;
+  error: string | null;
+  enable: () => Promise<boolean>;
+  disable: () => Promise<void>;
+  authenticate: (promptMessage?: string) => Promise<boolean>;
+}
+
+export const useBiometricAuth = (): UseBiometricAuthReturn => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
+
+  const isDeviceCompromised = useDeviceStore(s => s.isDeviceCompromised);
+  const biometricEnabled = useDeviceStore(s => s.biometricEnabled);
+  const setBiometricEnabledStore = useDeviceStore(s => s.setBiometricEnabled);
+
+  // Sync biometric state from SecureStore on mount and on foreground
+  const syncFromSecureStore = useCallback(async () => {
+    try {
+      const enabled = await isBiometricEnabled();
+      if (!isMountedRef.current) return;
+      setBiometricEnabledStore(enabled);
+      if (isDeviceCompromised && enabled) {
+        setBiometricEnabledStore(false);
+        setError('Biometric login is disabled because your device appears to be compromised.');
+      } else {
+        setError(null);
+      }
+    } catch {
+      // Ignore sync errors
+    }
+  }, [isDeviceCompromised, setBiometricEnabledStore]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const init = async () => {
+      try {
+        await syncFromSecureStore();
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    init();
+
+    const subscription = AppState.addEventListener('change', nextState => {
+      if (nextState === 'active') {
+        syncFromSecureStore();
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      isMountedRef.current = false;
+      subscription.remove();
+    };
+  }, [syncFromSecureStore]);
+
+  const enable = useCallback(async (): Promise<boolean> => {
+    try {
+      const enrolled = await isBiometricEnrolled();
+      if (!enrolled) {
+        setError('No biometric credentials enrolled on this device.');
+        return false;
+      }
+      await setBiometricEnabled(true);
+      setBiometricEnabledStore(true);
+      setError(null);
+      return true;
+    } catch {
+      setError('Failed to enable biometric login.');
+      return false;
+    }
+  }, [setBiometricEnabledStore]);
+
+  const disable = useCallback(async (): Promise<void> => {
+    await setBiometricEnabled(false);
+    setBiometricEnabledStore(false);
+    setError(null);
+  }, [setBiometricEnabledStore]);
+
+  const authenticate = useCallback(
+    async (promptMessage = 'Authenticate to continue'): Promise<boolean> => {
+      if (isDeviceCompromised) return false;
+      try {
+        const result = await authenticateWithBiometrics(promptMessage);
+        return result.success;
+      } catch {
+        return false;
+      }
+    },
+    [isDeviceCompromised]
+  );
+
+  const isAvailable = !isDeviceCompromised;
+  const isEnabled = !isDeviceCompromised && biometricEnabled;
+
+  return {
+    isAvailable,
+    isEnabled,
+    isLoading,
+    error,
+    enable,
+    disable,
+    authenticate,
+  };
+};

--- a/src/hooks/useCamera.ts
+++ b/src/hooks/useCamera.ts
@@ -2,6 +2,8 @@ import * as ImagePicker from 'expo-image-picker';
 import { useCallback, useEffect, useState } from 'react';
 import { Platform } from 'react-native';
 
+import { FeatureStatus, FeatureType } from '../services/featureCapabilities';
+import { useDegradationStore } from '../store/degradationStore';
 import { appLogger } from '../utils/logger';
 
 export enum CameraFallbackType {

--- a/src/hooks/useProfileData.ts
+++ b/src/hooks/useProfileData.ts
@@ -1,10 +1,9 @@
 import { useState, useCallback } from 'react';
 import { useForm } from 'react-hook-form';
 import { useRequireReauth } from './';
-import { cacheFormValues } from '../../services/formCache';
-import { configureNext } from '../../utils/layoutAnimation';
-// Assuming types are defined here or imported from a central types file
-import { ProfileData, ProfileTab } from '../../types/profile';
+import { cacheFormValues } from '../services/formCache';
+import { configureNext } from '../utils/layoutAnimation';
+import { ProfileData, ProfileTab } from '../types/profile';
 
 export const useProfileData = (initialData: ProfileData) => {
   const [profile, setProfile] = useState<ProfileData>(initialData);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -74,8 +74,12 @@ const LEVEL_EMOJI: Record<LogLevel, string> = {
 
 // ─── PRODUCTION BUILD INFORMATION ─────────────────────────────────────
 
-// @ts-ignore - Available in Expo/RN environment
-const APP_VERSION = typeof __EXPO_VERSION__ !== 'undefined' ? __EXPO_VERSION__ : '1.0.0';
+import Constants from 'expo-constants';
+import * as Crypto from 'expo-crypto';
+
+const APP_VERSION: string =
+  (Constants.expoConfig?.version as string) ?? '1.0.0';
+const SESSION_ID = Crypto.randomUUID();
 
 // ─── LOGGER IMPLEMENTATION ────────────────────────────────────────────────
 
@@ -156,7 +160,7 @@ class AppLogger {
       app: 'teachlink_mobile',
       version: APP_VERSION,
       environment: loggingConfig.isDev ? 'development' : 'production',
-      pid: String(process.pid || 0),
+      pid: SESSION_ID,
       userId: ctx.userId,
       requestId: ctx.requestId,
       component: ctx.component,


### PR DESCRIPTION
## Summary

This PR fixes four bugs that prevent key screens and hooks from functioning:

### Changes

1. **MobileSettings.tsx** (#943) — Added missing  import that caused a  on render, and implemented the empty  hook with SecureStore sync, AppState reactivity, and device-compromise handling.

2. **useCamera.ts** (#942) — Restored missing , , and  imports from the degradation module so the camera hook can report capability status and fallback modes.

3. **useProfileData.ts** (#941) — Fixed three import paths that used  (resolving outside ) instead of , preventing the hook from finding its dependencies at runtime.

4. **logger.ts** (#940) — Replaced the nonexistent  (always `"0"` on Hermes) with a per-session UUID and  (always `"1.0.0"`) with  from . Removed the `@ts-ignore`.

Closes #943
Closes #942
Closes #941
Closes #940